### PR TITLE
feat: dedicated Pending Requests screen (#11)

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -27,6 +27,7 @@ import { RootStackParamList, RootTabParamList } from "@navigation/types";
 import { colors } from "@theme/colors";
 import GoogleSignIn from "@screens/GoogleSignIn";
 import JoinRequestsScreen from "@screens/JoinRequestsScreen";
+import PendingRequestsScreen from "@screens/PendingRequestsScreen";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { BottomTabBarButtonProps } from "@react-navigation/bottom-tabs";
 
@@ -445,6 +446,14 @@ const AppNavigator = () => {
         <Stack.Screen
           name="JoinRequests"
           component={JoinRequestsScreen}
+          options={{
+            animation: "fade_from_bottom",
+            animationDuration: 200,
+          }}
+        />
+        <Stack.Screen
+          name="PendingRequests"
+          component={PendingRequestsScreen}
           options={{
             animation: "fade_from_bottom",
             animationDuration: 200,

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -32,6 +32,10 @@ export type RootStackParamList = {
       time: string;
     };
   };
+  PendingRequests: {
+    conversationId: number;
+    eventId: number;
+  };
   ChatThread: undefined;
 };
 

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -113,8 +113,7 @@ const ChatThreadScreen = () => {
     if (
       !activeConversation ||
       !activeConversation.eventId ||
-      !isConversationHost ||
-      activeEventGroupType !== "Single"
+      !isConversationHost
     ) {
       return;
     }
@@ -122,7 +121,7 @@ const ChatThreadScreen = () => {
       activeConversation.id,
       activeConversation.eventId,
       {
-        includeApproved: true,
+        includeApproved: activeEventGroupType === "Single",
       },
     ).catch(() => undefined);
   }, [activeConversation, activeEventGroupType, isConversationHost, refreshJoinRequests]);
@@ -180,13 +179,12 @@ const ChatThreadScreen = () => {
   };
 
   const isSendDisabled = draft.trim().length === 0;
-  const approvedJoinRequestCount = isConversationHost
-    ? joinRequests.filter((request) => request.status === "approved").length
+  const pendingJoinRequestCount = isConversationHost
+    ? joinRequests.filter((request) => request.status === "pending").length
     : 0;
   const canViewJoinRequests =
     isConversationHost &&
-    !!activeConversation?.eventId &&
-    activeEventGroupType === "Single";
+    !!activeConversation?.eventId;
 
   if (!activeConversation) {
     return null;
@@ -196,31 +194,13 @@ const ChatThreadScreen = () => {
     if (
       !activeConversation ||
       !activeConversation.eventId ||
-      !isConversationHost ||
-      activeEventGroupType !== "Single"
+      !isConversationHost
     ) {
       return;
     }
-    navigation.navigate("JoinRequests", {
+    navigation.navigate("PendingRequests", {
       conversationId: activeConversation.id,
       eventId: activeConversation.eventId,
-      title: activeConversation.event?.title ?? activeConversation.displayName,
-      groupType: "Single",
-      eventDetails: activeConversation.event
-        ? {
-            coverKey: activeConversation.event.coverKey,
-            dateLabel: activeConversation.event.dateLabel ?? "",
-            location: activeConversation.event.location ?? "",
-            time: activeConversation.event.time ?? "",
-          }
-        : activeEvent
-          ? {
-              coverKey: activeEvent.coverKey ?? undefined,
-              dateLabel: activeEvent.dateLabel,
-              location: activeEvent.location,
-              time: activeEvent.time,
-            }
-          : undefined,
     });
   };
 
@@ -344,19 +324,23 @@ const ChatThreadScreen = () => {
               <Text style={styles.threadSubtitle}>Connecting…</Text>
             ) : null}
           </Pressable>
-          {canViewJoinRequests && approvedJoinRequestCount > 0 ? (
+          {canViewJoinRequests ? (
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="View join requests"
               onPress={handleOpenJoinRequests}
+              style={styles.joinIconButton}
             >
-              <View style={styles.joinBadge}>
-                <Text style={styles.joinBadgeText}>
-                  {approvedJoinRequestCount > 99
-                    ? "99+"
-                    : approvedJoinRequestCount}
-                </Text>
-              </View>
+              <Feather name="users" size={20} color={colors.text} />
+              {pendingJoinRequestCount > 0 ? (
+                <View style={styles.joinCountBadge}>
+                  <Text style={styles.joinCountBadgeText}>
+                    {pendingJoinRequestCount > 99
+                      ? "99+"
+                      : pendingJoinRequestCount}
+                  </Text>
+                </View>
+              ) : null}
             </Pressable>
           ) : null}
         </View>
@@ -510,16 +494,27 @@ const styles = StyleSheet.create({
     fontSize: typography.caption,
     color: colors.muted,
   },
-  joinBadge: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: 16,
+  joinIconButton: {
     marginLeft: spacing.sm,
+    padding: spacing.xs,
   },
-  joinBadgeText: {
-    color: colors.buttonText,
+  joinCountBadge: {
+    position: "absolute",
+    top: 0,
+    right: -2,
+    backgroundColor: colors.accent,
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 3,
+  },
+  joinCountBadgeText: {
+    color: "#FFFFFF",
+    fontSize: 10,
     fontFamily: typography.fontFamilySemiBold,
+    lineHeight: 12,
   },
   errorText: {
     fontSize: typography.caption,

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Alert,
   FlatList,
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from "react-native";
-import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
+import { RouteProp, useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
 
@@ -85,9 +85,11 @@ const JoinRequestsScreen = () => {
       .finally(() => setIsRefreshing(false));
   }, [conversationId, eventId, refreshJoinRequests, is1to1Mode]);
 
-  useEffect(() => {
-    handleRefresh();
-  }, [handleRefresh]);
+  useFocusEffect(
+    useCallback(() => {
+      handleRefresh();
+    }, [handleRefresh]),
+  );
 
   const handleAction = useCallback(
     async (_requestId: number, userId: number, action: "approve" | "deny") => {
@@ -228,12 +230,13 @@ const JoinRequestsScreen = () => {
     setReportError(null);
   }, []);
 
-  // Group mode empty state
   const listEmpty = useMemo(
     () => (
       <View style={styles.emptyState}>
         <Text style={styles.emptyTitle}>
-          {is1to1Mode ? "No accepted users yet" : "No pending requests"}
+          {is1to1Mode
+            ? "No accepted users yet"
+            : "No pending requests"}
         </Text>
         {!is1to1Mode && (
           <Text style={styles.emptySubtitle}>
@@ -303,6 +306,11 @@ const JoinRequestsScreen = () => {
       });
   }, [conversationById, is1to1Mode, requests]);
 
+  const pendingRequests = useMemo(
+    () => requests.filter((request) => request.status === "pending"),
+    [requests],
+  );
+
   // 1:1 mode header
   const render1to1Header = () => {
     if (!eventDetails) return null;
@@ -338,10 +346,20 @@ const JoinRequestsScreen = () => {
             </Text>
           </View>
         </Pressable>
-        {displayRequests.length > 0 && (
-          <View style={styles.badgeContainer}>
-            <Text style={styles.badgeText}>{displayRequests.length}</Text>
-          </View>
+        {pendingRequests.length > 0 && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="View pending requests"
+            onPress={() => navigation.navigate("PendingRequests", { conversationId, eventId })}
+            style={styles.joinIconButton}
+          >
+            <Feather name="users" size={20} color={colors.text} />
+            <View style={styles.joinCountBadge}>
+              <Text style={styles.joinCountBadgeText}>
+                {pendingRequests.length}
+              </Text>
+            </View>
+          </Pressable>
         )}
       </View>
     );
@@ -459,7 +477,11 @@ const JoinRequestsScreen = () => {
         <FlatList
           data={displayRequests}
           keyExtractor={(item) => String(item.id)}
-          renderItem={is1to1Mode ? render1to1RequestItem : renderGroupRequestItem}
+          renderItem={
+            is1to1Mode
+              ? render1to1RequestItem
+              : renderGroupRequestItem
+          }
           ItemSeparatorComponent={() => (
             <View
               style={is1to1Mode ? styles.separator1to1 : styles.separator}
@@ -587,22 +609,27 @@ const styles = StyleSheet.create({
     color: "#707070",
     marginTop: 2,
   },
-  badgeContainer: {
-    backgroundColor: "#E6E6E6",
-    borderRadius: 24,
-    minWidth: 24,
-    height: 24,
+  joinIconButton: {
+    marginLeft: spacing.sm,
+    padding: spacing.xs,
+  },
+  joinCountBadge: {
+    position: "absolute",
+    top: 0,
+    right: -2,
+    backgroundColor: colors.accent,
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: spacing.xs,
+    paddingHorizontal: 3,
   },
-  badgeText: {
-    fontSize: 15,
+  joinCountBadgeText: {
+    color: "#FFFFFF",
+    fontSize: 10,
     fontFamily: typography.fontFamilySemiBold,
-    fontWeight: "600",
-    lineHeight: 20,
-    textAlign: "center",
-    color: "#494949",
+    lineHeight: 12,
   },
   // List styles
   listContent: {

--- a/src/screens/PendingRequestsScreen.tsx
+++ b/src/screens/PendingRequestsScreen.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { Feather } from "@expo/vector-icons";
+
+import { colors, spacing, typography } from "@theme/index";
+import { useChat, ChatJoinRequest } from "@context/ChatContext";
+import { RootStackParamList } from "@navigation/types";
+import ScreenContainer from "@components/ScreenContainer";
+
+type PendingRequestsRoute = RouteProp<RootStackParamList, "PendingRequests">;
+type PendingRequestsNavigation = NativeStackNavigationProp<
+  RootStackParamList,
+  "PendingRequests"
+>;
+
+const AVATAR_COLORS = [
+  "#4CAF50",
+  "#9C27B0",
+  "#FF9800",
+  "#2196F3",
+  "#E91E63",
+  "#00BCD4",
+  "#8BC34A",
+  "#673AB7",
+];
+
+const getAvatarColor = (userId: number) =>
+  AVATAR_COLORS[userId % AVATAR_COLORS.length];
+
+const PendingRequestsScreen = () => {
+  const navigation = useNavigation<PendingRequestsNavigation>();
+  const route = useRoute<PendingRequestsRoute>();
+  const {
+    joinRequestsByConversation,
+    refreshJoinRequests,
+    approveJoinRequest,
+    denyJoinRequest,
+  } = useChat();
+  const { conversationId, eventId } = route.params;
+  const requests = joinRequestsByConversation[conversationId] ?? [];
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [acceptingUserId, setAcceptingUserId] = useState<number | null>(null);
+  const [decliningUserId, setDecliningUserId] = useState<number | null>(null);
+  const [expandedRequestIds, setExpandedRequestIds] = useState<Set<number>>(
+    () => new Set(),
+  );
+
+  const pendingRequests = useMemo(
+    () => requests.filter((request) => request.status === "pending"),
+    [requests],
+  );
+
+  const handleRefresh = useCallback(() => {
+    setIsRefreshing(true);
+    refreshJoinRequests(conversationId, eventId)
+      .catch(() => undefined)
+      .finally(() => setIsRefreshing(false));
+  }, [conversationId, eventId, refreshJoinRequests]);
+
+  useEffect(() => {
+    refreshJoinRequests(conversationId, eventId).catch(() => undefined);
+  }, [conversationId, eventId, refreshJoinRequests]);
+
+  const handleAccept = useCallback(
+    async (request: ChatJoinRequest) => {
+      setAcceptingUserId(request.userId);
+      try {
+        await approveJoinRequest(conversationId, eventId, request.userId);
+        await refreshJoinRequests(conversationId, eventId);
+      } catch {
+        // silently fail
+      } finally {
+        setAcceptingUserId(null);
+      }
+    },
+    [approveJoinRequest, conversationId, eventId, refreshJoinRequests],
+  );
+
+  const handleDecline = useCallback(
+    async (request: ChatJoinRequest) => {
+      setDecliningUserId(request.userId);
+      try {
+        await denyJoinRequest(conversationId, eventId, request.userId);
+        await refreshJoinRequests(conversationId, eventId);
+      } catch {
+        // silently fail
+      } finally {
+        setDecliningUserId(null);
+      }
+    },
+    [conversationId, denyJoinRequest, eventId, refreshJoinRequests],
+  );
+
+  const toggleRequestExpanded = (requestId: number) => {
+    setExpandedRequestIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(requestId)) {
+        next.delete(requestId);
+      } else {
+        next.add(requestId);
+      }
+      return next;
+    });
+  };
+
+  const renderItem = ({ item }: { item: ChatJoinRequest }) => {
+    const initial = item.requester.name?.charAt(0).toUpperCase() ?? "?";
+    const avatarColor = getAvatarColor(item.userId);
+    const isExpanded = expandedRequestIds.has(item.id);
+    const isAccepting = acceptingUserId === item.userId;
+    const isDeclining = decliningUserId === item.userId;
+    const isLoading = isAccepting || isDeclining;
+
+    return (
+      <View style={styles.requestItem}>
+        <View style={[styles.avatar, { backgroundColor: avatarColor }]}>
+          <Text style={styles.avatarText}>{initial}</Text>
+        </View>
+
+        <View style={styles.requestContent}>
+          <Text style={styles.requestName}>{item.requester.name}</Text>
+          <Text
+            style={styles.requestMessage}
+            numberOfLines={isExpanded ? undefined : 3}
+          >
+            {item.message}
+          </Text>
+          {!isExpanded && item.message.length > 100 && (
+            <Text
+              style={styles.seeMoreText}
+              onPress={() => toggleRequestExpanded(item.id)}
+            >
+              See more
+            </Text>
+          )}
+        </View>
+
+        <View style={styles.requestActions}>
+          <Pressable
+            style={[styles.actionButton, styles.declineButton]}
+            onPress={() => handleDecline(item)}
+            disabled={isLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Decline request"
+          >
+            {isDeclining ? (
+              <ActivityIndicator size="small" color={colors.text} />
+            ) : (
+              <Feather name="x" size={18} color={colors.text} />
+            )}
+          </Pressable>
+
+          <Pressable
+            style={[styles.actionButton, styles.acceptButton]}
+            onPress={() => handleAccept(item)}
+            disabled={isLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Accept request"
+          >
+            {isAccepting ? (
+              <ActivityIndicator size="small" color={colors.buttonText} />
+            ) : (
+              <Feather name="check" size={18} color={colors.buttonText} />
+            )}
+          </Pressable>
+        </View>
+      </View>
+    );
+  };
+
+  const listEmpty = useMemo(
+    () => (
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyTitle}>No pending requests</Text>
+      </View>
+    ),
+    [],
+  );
+
+  return (
+    <ScreenContainer edges={["top", "bottom"]}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => navigation.goBack()}
+            style={styles.backButton}
+          >
+            <Feather name="chevron-left" size={24} color="#707070" />
+          </Pressable>
+          <Text style={styles.headerTitle}>
+            Requests ({pendingRequests.length})
+          </Text>
+        </View>
+        <FlatList
+          data={pendingRequests}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderItem}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          contentContainerStyle={
+            pendingRequests.length === 0
+              ? styles.listEmptyContent
+              : styles.listContent
+          }
+          ListEmptyComponent={listEmpty}
+          onRefresh={handleRefresh}
+          refreshing={isRefreshing}
+        />
+      </View>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    paddingTop: spacing.lg - spacing.md,
+    paddingBottom: spacing.md,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  backButton: {
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.xs,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontFamily: typography.fontFamilyMedium,
+    fontWeight: "500",
+    lineHeight: 20,
+    letterSpacing: -0.5,
+    color: "#000000",
+  },
+  listContent: {
+    paddingBottom: spacing.xl,
+  },
+  listEmptyContent: {
+    flexGrow: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  separator: {
+    height: 1,
+    backgroundColor: colors.border,
+  },
+  requestItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarText: {
+    fontSize: typography.subtitle,
+    fontFamily: typography.fontFamilySemiBold,
+    color: "#FFFFFF",
+  },
+  requestContent: {
+    flex: 1,
+  },
+  requestName: {
+    fontSize: 16,
+    fontFamily: typography.fontFamilyMedium,
+    color: colors.text,
+    lineHeight: 20,
+    letterSpacing: -0.5,
+  },
+  requestMessage: {
+    fontSize: 15,
+    fontFamily: typography.fontFamilyRegular,
+    color: "#707070",
+    lineHeight: 20,
+    letterSpacing: -0.5,
+    marginTop: 2,
+  },
+  seeMoreText: {
+    fontSize: 15,
+    fontFamily: typography.fontFamilyMedium,
+    color: "#707070",
+    lineHeight: 20,
+    letterSpacing: -0.5,
+    marginTop: 2,
+  },
+  requestActions: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    alignItems: "flex-start",
+    marginTop: spacing.xs,
+  },
+  actionButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  declineButton: {
+    backgroundColor: "#E6E6E6",
+  },
+  acceptButton: {
+    backgroundColor: colors.text,
+  },
+  emptyState: {
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  emptyTitle: {
+    fontFamily: typography.fontFamilySemiBold,
+    fontSize: typography.title,
+    color: colors.text,
+    textAlign: "center",
+  },
+});
+
+export default PendingRequestsScreen;

--- a/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
+++ b/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
@@ -315,7 +315,7 @@ describe('ChatThreadScreen Rendering', () => {
   });
 
   describe('Join Request Badge', () => {
-    it('should display join request badge for host in 1:1 events with approved users', () => {
+    it('should display join request icon for host with pending count badge', () => {
       const singleHostConversation = {
         ...mockConversations[0],
         id: 99,
@@ -335,16 +335,19 @@ describe('ChatThreadScreen Rendering', () => {
           activeConversationId: 99,
           conversations: [singleHostConversation],
           joinRequestsByConversation: {
-            99: [{ id: 1, eventId: 2, userId: 3, message: 'Hi', status: 'approved', createdAt: '', requester: { id: 3, name: 'User' } }],
+            99: [
+              { id: 1, eventId: 2, userId: 3, message: 'Hi', status: 'pending', createdAt: '', requester: { id: 3, name: 'User' } },
+            ],
           },
         },
       });
-      const { getByText } = render(<ChatThreadScreen />);
+      const { getByLabelText, getByText } = render(<ChatThreadScreen />);
 
+      expect(getByLabelText('View join requests')).toBeTruthy();
       expect(getByText('1')).toBeTruthy();
     });
 
-    it('should not display join request badge for group events', () => {
+    it('should display join request icon for group events when host', () => {
       setupMocks({
         chatOverrides: {
           activeConversationId: 1,
@@ -353,9 +356,75 @@ describe('ChatThreadScreen Rendering', () => {
           },
         },
       });
-      const { queryByLabelText } = render(<ChatThreadScreen />);
+      const { getByLabelText } = render(<ChatThreadScreen />);
 
-      expect(queryByLabelText('View join requests')).toBeNull();
+      expect(getByLabelText('View join requests')).toBeTruthy();
+    });
+
+    it('should display join request icon for 1:1 host with only pending requests (no accepted)', () => {
+      const singleHostConversation = {
+        ...mockConversations[0],
+        id: 99,
+        eventId: 2,
+        event: {
+          id: 2,
+          userId: 1,
+          title: 'Hiking Adventure',
+          location: 'Mountain Trail',
+          time: '08:00',
+          dateLabel: 'Tmrw',
+          groupType: 'Single',
+        },
+      };
+      setupMocks({
+        chatOverrides: {
+          activeConversationId: 99,
+          conversations: [singleHostConversation],
+          joinRequestsByConversation: {
+            99: [
+              { id: 1, eventId: 2, userId: 3, message: 'Hi', status: 'pending', createdAt: '', requester: { id: 3, name: 'User A' } },
+              { id: 2, eventId: 2, userId: 4, message: 'Hello', status: 'pending', createdAt: '', requester: { id: 4, name: 'User B' } },
+            ],
+          },
+        },
+      });
+      const { getByLabelText, getByText } = render(<ChatThreadScreen />);
+
+      expect(getByLabelText('View join requests')).toBeTruthy();
+      expect(getByText('2')).toBeTruthy();
+    });
+
+    it('should display join request icon without count when no pending requests', () => {
+      const singleHostConversation = {
+        ...mockConversations[0],
+        id: 99,
+        eventId: 2,
+        event: {
+          id: 2,
+          userId: 1,
+          title: 'Hiking Adventure',
+          location: 'Mountain Trail',
+          time: '08:00',
+          dateLabel: 'Tmrw',
+          groupType: 'Single',
+        },
+      };
+      setupMocks({
+        chatOverrides: {
+          activeConversationId: 99,
+          conversations: [singleHostConversation],
+          joinRequestsByConversation: {
+            99: [
+              { id: 1, eventId: 2, userId: 3, message: 'Hi', status: 'approved', createdAt: '', requester: { id: 3, name: 'User' } },
+            ],
+          },
+        },
+      });
+      const { getByLabelText, queryByText } = render(<ChatThreadScreen />);
+
+      // Icon shows but no count badge
+      expect(getByLabelText('View join requests')).toBeTruthy();
+      expect(queryByText('1')).toBeNull();
     });
 
     it('should not display join request badge when user is not host', () => {

--- a/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
@@ -31,6 +31,7 @@ const mockRouteParams = {
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
+  const React = require('react');
   return {
     ...actualNav,
     useNavigation: () => ({
@@ -44,6 +45,9 @@ jest.mock('@react-navigation/native', () => {
       name: 'JoinRequests',
       params: mockRouteParams,
     }),
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => { cb(); }, [cb]);
+    },
   };
 });
 
@@ -426,21 +430,23 @@ describe('JoinRequestsScreen Rendering', () => {
       expect(getByText('Today, 10:00 at Central Park')).toBeTruthy();
     });
 
-    it('should render request count badge in 1:1 mode', () => {
-      const { getByText } = render(<JoinRequestsScreen />);
+    it('should render pending requests icon with count badge in 1:1 mode', () => {
+      const { getByText, getByTestId } = render(<JoinRequestsScreen />);
 
-      // Badge shows count of approved users only
-      expect(getByText('2')).toBeTruthy();
+      // Users icon + badge with pending count
+      expect(getByTestId('icon-users')).toBeTruthy();
+      expect(getByText('1')).toBeTruthy();
     });
 
-    it('should not render badge when no requests in 1:1 mode', () => {
-      mockChatValue.joinRequestsByConversation = { 1: [] };
+    it('should not render pending requests icon when no pending requests in 1:1 mode', () => {
+      // All requests are approved, no pending
+      mockChatValue.joinRequestsByConversation = {
+        1: [mockJoinRequests[0], mockJoinRequests[1]],
+      };
 
-      const { queryByText } = render(<JoinRequestsScreen />);
+      const { queryByTestId } = render(<JoinRequestsScreen />);
 
-      // No badge should be rendered
-      const badge = queryByText('0');
-      expect(badge).toBeNull();
+      expect(queryByTestId('icon-users')).toBeNull();
     });
   });
 
@@ -611,7 +617,6 @@ describe('JoinRequestsScreen Rendering', () => {
       const { getByText, queryByText } = render(<JoinRequestsScreen />);
 
       expect(getByText('No accepted users yet')).toBeTruthy();
-      // 1:1 mode does not show the attendees explanation
       expect(
         queryByText("You'll see new join requests here when attendees tap Interested.")
       ).toBeNull();
@@ -665,6 +670,59 @@ describe('JoinRequestsScreen Rendering', () => {
       await waitFor(() => {
         expect(mockSetActiveConversation).not.toHaveBeenCalled();
         expect(mockReplace).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('1:1 Mode - Only Pending Requests (no accepted users)', () => {
+    const onlyPendingRequests = [
+      {
+        id: 10,
+        eventId: 1,
+        userId: 5,
+        message: 'Would love to join!',
+        status: 'pending' as const,
+        createdAt: new Date().toISOString(),
+        requester: { id: 5, name: 'Pending User 1' },
+      },
+      {
+        id: 11,
+        eventId: 1,
+        userId: 6,
+        message: 'Interested!',
+        status: 'pending' as const,
+        createdAt: new Date(Date.now() - 3600000).toISOString(),
+        requester: { id: 6, name: 'Pending User 2' },
+      },
+    ];
+
+    beforeEach(() => {
+      mockRouteParams.groupType = 'Single';
+      mockChatValue.joinRequestsByConversation = { 1: onlyPendingRequests };
+    });
+
+    it('should show pending count badge when there are only pending requests', () => {
+      const { getByText, getByTestId } = render(<JoinRequestsScreen />);
+
+      // Users icon + badge with pending count
+      expect(getByTestId('icon-users')).toBeTruthy();
+      expect(getByText('2')).toBeTruthy();
+    });
+
+    it('should show empty accepted state by default', () => {
+      const { getByText } = render(<JoinRequestsScreen />);
+
+      expect(getByText('No accepted users yet')).toBeTruthy();
+    });
+
+    it('should navigate to PendingRequests when badge icon is pressed', () => {
+      const { getByLabelText } = render(<JoinRequestsScreen />);
+
+      fireEvent.press(getByLabelText('View pending requests'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('PendingRequests', {
+        conversationId: 1,
+        eventId: 1,
       });
     });
   });

--- a/src/screens/__tests__/PendingRequestsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/PendingRequestsScreen.rendering.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Rendering tests for PendingRequestsScreen
+ * Tests header, request list, accept/decline actions, and empty state
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import PendingRequestsScreen from '../PendingRequestsScreen';
+
+// Mock navigation
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+const mockRouteParams = {
+  conversationId: 1,
+  eventId: 1,
+};
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+      setOptions: jest.fn(),
+    }),
+    useRoute: () => ({
+      key: 'test-key',
+      name: 'PendingRequests',
+      params: mockRouteParams,
+    }),
+  };
+});
+
+// Mock safe area context
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Mock join requests data
+const mockPendingRequests = [
+  {
+    id: 1,
+    eventId: 1,
+    userId: 2,
+    message: 'I would love to join this coffee meetup!',
+    status: 'pending' as const,
+    createdAt: new Date().toISOString(),
+    requester: { id: 2, name: 'Jane Doe' },
+  },
+  {
+    id: 2,
+    eventId: 1,
+    userId: 3,
+    message: 'Sounds fun!',
+    status: 'pending' as const,
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
+    requester: { id: 3, name: 'John Smith' },
+  },
+];
+
+const mockMixedRequests = [
+  ...mockPendingRequests,
+  {
+    id: 3,
+    eventId: 1,
+    userId: 4,
+    message: 'Already approved',
+    status: 'approved' as const,
+    createdAt: new Date(Date.now() - 7200000).toISOString(),
+    requester: { id: 4, name: 'Alice Brown' },
+  },
+];
+
+// Mock ChatContext
+const mockApproveJoinRequest = jest.fn().mockResolvedValue(undefined);
+const mockDenyJoinRequest = jest.fn().mockResolvedValue(undefined);
+const mockRefreshJoinRequests = jest.fn().mockResolvedValue(undefined);
+
+let mockChatValue = {
+  joinRequestsByConversation: { 1: mockPendingRequests } as Record<number, typeof mockMixedRequests>,
+  refreshJoinRequests: mockRefreshJoinRequests,
+  approveJoinRequest: mockApproveJoinRequest,
+  denyJoinRequest: mockDenyJoinRequest,
+  setActiveConversation: jest.fn(),
+  conversations: [],
+  activeConversationId: null,
+  isConnecting: false,
+  error: null,
+  refreshConversations: jest.fn(),
+  isRefreshingConversations: false,
+  messages: [],
+  sendMessage: jest.fn(),
+  retryMessage: jest.fn(),
+  reportMember: jest.fn(),
+};
+
+jest.mock('@context/ChatContext', () => ({
+  useChat: () => mockChatValue,
+  ChatJoinRequest: {},
+}));
+
+// Mock components
+jest.mock('@components/ScreenContainer', () => {
+  const { View } = require('react-native');
+  return ({ children, edges }: { children: React.ReactNode; edges?: string[] }) => (
+    <View testID="screen-container">{children}</View>
+  );
+});
+
+// Mock Feather icons
+jest.mock('@expo/vector-icons', () => ({
+  Feather: ({ name, ...props }: { name: string }) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View testID={`icon-${name}`} {...props}>
+        <Text>{name}</Text>
+      </View>
+    );
+  },
+}));
+
+describe('PendingRequestsScreen Rendering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChatValue = {
+      joinRequestsByConversation: { 1: mockPendingRequests },
+      refreshJoinRequests: mockRefreshJoinRequests,
+      approveJoinRequest: mockApproveJoinRequest,
+      denyJoinRequest: mockDenyJoinRequest,
+      setActiveConversation: jest.fn(),
+      conversations: [],
+      activeConversationId: null,
+      isConnecting: false,
+      error: null,
+      refreshConversations: jest.fn(),
+      isRefreshingConversations: false,
+      messages: [],
+      sendMessage: jest.fn(),
+      retryMessage: jest.fn(),
+      reportMember: jest.fn(),
+    };
+  });
+
+  describe('Header', () => {
+    it('should render header with correct pending count', () => {
+      const { getByText } = render(<PendingRequestsScreen />);
+      expect(getByText('Requests (2)')).toBeTruthy();
+    });
+
+    it('should render back button', () => {
+      const { getByTestId } = render(<PendingRequestsScreen />);
+      expect(getByTestId('icon-chevron-left')).toBeTruthy();
+    });
+
+    it('should navigate back when back button is pressed', () => {
+      const { getByTestId } = render(<PendingRequestsScreen />);
+      const backButton = getByTestId('icon-chevron-left').parent?.parent;
+      if (backButton) {
+        fireEvent.press(backButton);
+        expect(mockGoBack).toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('Request List', () => {
+    it('should render requester names', () => {
+      const { getByText } = render(<PendingRequestsScreen />);
+      expect(getByText('Jane Doe')).toBeTruthy();
+      expect(getByText('John Smith')).toBeTruthy();
+    });
+
+    it('should render request messages', () => {
+      const { getByText } = render(<PendingRequestsScreen />);
+      expect(getByText('I would love to join this coffee meetup!')).toBeTruthy();
+      expect(getByText('Sounds fun!')).toBeTruthy();
+    });
+
+    it('should render avatar with correct initial', () => {
+      const { getAllByText } = render(<PendingRequestsScreen />);
+      expect(getAllByText('J').length).toBe(2); // Jane & John
+    });
+
+    it('should only show pending requests, not approved', () => {
+      mockChatValue.joinRequestsByConversation = { 1: mockMixedRequests };
+      const { getByText, queryByText } = render(<PendingRequestsScreen />);
+
+      expect(getByText('Jane Doe')).toBeTruthy();
+      expect(getByText('John Smith')).toBeTruthy();
+      expect(queryByText('Alice Brown')).toBeNull();
+      expect(getByText('Requests (2)')).toBeTruthy();
+    });
+  });
+
+  describe('Accept Action', () => {
+    it('should call approveJoinRequest when accept button is pressed', async () => {
+      const { getAllByLabelText } = render(<PendingRequestsScreen />);
+
+      const acceptButtons = getAllByLabelText('Accept request');
+      fireEvent.press(acceptButtons[0]);
+
+      await waitFor(() => {
+        expect(mockApproveJoinRequest).toHaveBeenCalledWith(1, 1, 2);
+      });
+    });
+  });
+
+  describe('Decline Action', () => {
+    it('should call denyJoinRequest when decline button is pressed', async () => {
+      const { getAllByLabelText } = render(<PendingRequestsScreen />);
+
+      const declineButtons = getAllByLabelText('Decline request');
+      fireEvent.press(declineButtons[0]);
+
+      await waitFor(() => {
+        expect(mockDenyJoinRequest).toHaveBeenCalledWith(1, 1, 2);
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show empty state when no pending requests', () => {
+      mockChatValue.joinRequestsByConversation = { 1: [] };
+      const { getByText } = render(<PendingRequestsScreen />);
+      expect(getByText('No pending requests')).toBeTruthy();
+    });
+
+    it('should show empty state when all requests are approved', () => {
+      mockChatValue.joinRequestsByConversation = {
+        1: [{
+          id: 1,
+          eventId: 1,
+          userId: 2,
+          message: 'Hi',
+          status: 'approved' as const,
+          createdAt: new Date().toISOString(),
+          requester: { id: 2, name: 'Jane Doe' },
+        }],
+      };
+      const { getByText } = render(<PendingRequestsScreen />);
+      expect(getByText('No pending requests')).toBeTruthy();
+      expect(getByText('Requests (0)')).toBeTruthy();
+    });
+  });
+
+  describe('Refresh', () => {
+    it('should call refreshJoinRequests on mount', async () => {
+      render(<PendingRequestsScreen />);
+
+      await waitFor(() => {
+        expect(mockRefreshJoinRequests).toHaveBeenCalledWith(1, 1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `PendingRequestsScreen` with colored avatars, name, message preview, and circular accept/decline buttons matching the design mockup
- ChatThreadScreen and JoinRequestsScreen now navigate to `PendingRequests` via users icon + pending count badge
- Replace toggle badge in JoinRequestsScreen 1:1 header with navigation icon to PendingRequests
- Use `useFocusEffect` in JoinRequestsScreen so approved users appear immediately when navigating back from PendingRequests

## Test plan
- [x] All 77 tests pass across PendingRequestsScreen, ChatThreadScreen, and JoinRequestsScreen test files
- [ ] Host of 1:1 event with pending requests → tap users icon → see "Requests (N)" page → accept/decline works
- [ ] Host of group event with pending requests → tap users icon → same screen, same behavior
- [ ] After accepting/declining all → list refreshes, shows empty state
- [ ] Navigate back to JoinRequestsScreen after approving → approved user appears without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)