### PR TITLE
fix: avatar/name display in group chat & report-unblock cleanup

### DIFF
--- a/server/api_integration_test.go
+++ b/server/api_integration_test.go
@@ -1961,15 +1961,12 @@ func TestReportMember(t *testing.T) {
 		}
 	})
 
-	t.Run("idempotent unblock returns already_unblocked", func(t *testing.T) {
+	t.Run("idempotent unblock returns 404 when already fully unblocked", func(t *testing.T) {
 		resp := env.doRequest(t, http.MethodDelete, fmt.Sprintf("/api/events/%d/members/%d/block", eventID, noahUser.ID), avaToken, nil)
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 (report and block already deleted), got %d", resp.StatusCode)
 		}
-		payload := decodeJSON[unblockMemberResponse](t, resp)
-		if !payload.AlreadyUnblocked {
-			t.Fatal("expected already_unblocked=true on second unblock")
-		}
+		resp.Body.Close()
 	})
 
 	t.Run("unblock restores mutual event visibility", func(t *testing.T) {

--- a/server/chat_hub.go
+++ b/server/chat_hub.go
@@ -1738,13 +1738,25 @@ func (h *ChatHTTPHandler) unblockMember(c *gin.Context) {
 		return
 	}
 	if !hasMemberReport {
-		c.JSON(http.StatusNotFound, gin.H{"error": "no report-block relationship found for this member"})
-		return
+		hasBlock, err := h.repo.IsUserBlocked(ctx, claims.UserID, targetUserID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check block status"})
+			return
+		}
+		if !hasBlock {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no report-block relationship found for this member"})
+			return
+		}
 	}
 
 	deletedAny, err := h.repo.DeleteMutualBlock(ctx, claims.UserID, targetUserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to unblock member"})
+		return
+	}
+
+	if err := h.repo.DeleteMemberReport(ctx, eventID, claims.UserID, targetUserID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete member report"})
 		return
 	}
 

--- a/server/repository.go
+++ b/server/repository.go
@@ -227,6 +227,17 @@ WHERE cm.conversation_id = ?
 ORDER BY cm.joined_at ASC;
 `
 
+const selectFormerMessageSenders = `
+SELECT DISTINCT m.sender_id, u.name
+FROM messages m
+JOIN users u ON u.id = m.sender_id
+WHERE m.conversation_id = ?
+  AND m.sender_id NOT IN (
+    SELECT user_id FROM conversation_members WHERE conversation_id = ?
+  )
+ORDER BY m.sender_id ASC;
+`
+
 const selectMessagesForConversation = `
 SELECT id, conversation_id, sender_id, body, attachment_url, delivery_status, created_at
 FROM messages
@@ -2453,6 +2464,23 @@ func (r *EventRepository) fetchConversationParticipants(ctx context.Context, con
 	}
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("iterate conversation participants: %w", err)
+	}
+
+	// Append former message senders to participants only (not memberIDs)
+	rows2, err := r.db.QueryContext(ctx, selectFormerMessageSenders, conversationID, conversationID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list former message senders: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var p ConversationParticipant
+		if err := rows2.Scan(&p.ID, &p.Name); err != nil {
+			return nil, nil, fmt.Errorf("scan former message sender: %w", err)
+		}
+		participants = append(participants, p)
+	}
+	if err := rows2.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate former message senders: %w", err)
 	}
 
 	return participants, memberIDs, nil

--- a/server/repository.go
+++ b/server/repository.go
@@ -496,6 +496,11 @@ WHERE blocker_user_id = ? AND blocked_user_id = ?
 LIMIT 1;
 `
 
+const deleteMemberReportByEventAndUsers = `
+DELETE FROM event_reports
+WHERE event_id = ? AND user_id = ? AND reported_user_id = ?;
+`
+
 const selectMemberReportRelationship = `
 SELECT 1
 FROM event_reports
@@ -3098,6 +3103,14 @@ func (r *EventRepository) HasMemberReport(ctx context.Context, eventID, hostUser
 		return false, fmt.Errorf("check member report relationship: %w", err)
 	}
 	return true, nil
+}
+
+func (r *EventRepository) DeleteMemberReport(ctx context.Context, eventID, reporterUserID, reportedUserID int64) error {
+	_, err := r.db.ExecContext(ctx, deleteMemberReportByEventAndUsers, eventID, reporterUserID, reportedUserID)
+	if err != nil {
+		return fmt.Errorf("delete member report: %w", err)
+	}
+	return nil
 }
 
 // ListHostEventIDsForMember returns event IDs owned by hostUserID where

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -731,6 +731,15 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
                 }
               : conversation,
           );
+
+          // If sender is not in participants, refresh to get updated list
+          if (message.senderId !== currentUserId) {
+            const convo = prev.find((c) => c.id === message.conversationId);
+            if (convo && !convo.participants?.some((p) => p.id === message.senderId)) {
+              refreshConversations().catch(() => undefined);
+            }
+          }
+
           return sortConversationsByActivity(updated);
         });
         return;

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -99,6 +99,15 @@ const ChatThreadScreen = () => {
     return user.id === activeConversation.createdBy;
   }, [activeConversation, user]);
 
+  const isGroupConversation = useMemo(() => {
+    if (!activeConversation) return false;
+    return (
+      activeConversation.memberIds.length > 2 ||
+      !!activeConversation.title ||
+      !!activeConversation.eventId
+    );
+  }, [activeConversation]);
+
   useEffect(() => {
     if (!activeConversationId) {
       if (navigation.canGoBack()) {
@@ -221,8 +230,14 @@ const ChatThreadScreen = () => {
     const participant = activeConversation.participants?.find(
       (p) => p.id === item.senderId,
     );
-    const avatarLabel =
-      participant?.name ?? activeConversation.displayName ?? "";
+    const senderName = participant?.name ?? "";
+    const initials = senderName
+      .split(" ")
+      .map((w: string) => w[0] ?? "")
+      .slice(0, 2)
+      .join("")
+      .toUpperCase();
+    const avatarColor = `hsl(${(item.senderId * 47) % 360}, 55%, 45%)`;
 
     const bubble = (
       <View
@@ -270,6 +285,8 @@ const ChatThreadScreen = () => {
       bubble
     );
 
+    const showAvatar = !isOwn && isGroupConversation;
+
     return (
       <View
         style={[
@@ -277,7 +294,17 @@ const ChatThreadScreen = () => {
           isOwn ? styles.messageRowOwn : styles.messageRowOther,
         ]}
       >
-        <View style={styles.messageBubbleContainer}>{bubbleContent}</View>
+        {showAvatar ? (
+          <View style={[styles.avatarCircle, { backgroundColor: avatarColor }]}>
+            <Text style={styles.avatarInitials}>{initials}</Text>
+          </View>
+        ) : null}
+        <View style={styles.messageBubbleContainer}>
+          {showAvatar && senderName ? (
+            <Text style={styles.senderName}>{senderName}</Text>
+          ) : null}
+          {bubbleContent}
+        </View>
       </View>
     );
   };
@@ -534,15 +561,38 @@ const styles = StyleSheet.create({
   },
   messageRow: {
     marginBottom: spacing.sm,
-  },
-  messageRowOwn: {
+    flexDirection: "row",
     alignItems: "flex-end",
   },
+  messageRowOwn: {
+    justifyContent: "flex-end",
+  },
   messageRowOther: {
-    alignItems: "flex-start",
+    justifyContent: "flex-start",
   },
   messageBubbleContainer: {
-    maxWidth: "80%",
+    maxWidth: "75%",
+  },
+  avatarCircle: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: spacing.xs,
+    flexShrink: 0,
+  },
+  avatarInitials: {
+    color: "#FFFFFF",
+    fontSize: 11,
+    fontFamily: typography.fontFamilySemiBold,
+  },
+  senderName: {
+    fontSize: typography.caption,
+    color: colors.subText,
+    fontFamily: typography.fontFamilySemiBold,
+    marginBottom: 2,
+    marginLeft: spacing.xs,
   },
   messageBubble: {
     paddingHorizontal: spacing.md,

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -242,9 +242,13 @@ const ChatThreadScreen = () => {
     const avatarColor = `hsl(${(item.senderId * 47) % 360}, 55%, 45%)`;
 
     const prevMessage = index > 0 ? messages[index - 1] : null;
+    const prevIsSystem = prevMessage
+      ? prevMessage.body.toLowerCase().endsWith("joined the chat") ||
+        prevMessage.body.toLowerCase() === "updated event detail"
+      : false;
     const isFirstInRun =
-      !prevMessage || prevMessage.senderId !== item.senderId;
-    const showAvatar = !isOwn && isGroupConversation;
+      !prevMessage || prevMessage.senderId !== item.senderId || prevIsSystem;
+    const showAvatar = !isOwn;
     const showName = showAvatar && isFirstInRun;
 
     const timeText = item.pending

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -213,7 +213,7 @@ const ChatThreadScreen = () => {
     });
   };
 
-  const renderMessage = ({ item }: { item: (typeof messages)[number] }) => {
+  const renderMessage = ({ item, index }: { item: (typeof messages)[number]; index: number }) => {
     const lowerBody = item.body.toLowerCase();
     const isJoinSystemMessage = lowerBody.endsWith("joined the chat");
     const isEventUpdateSystemMessage = lowerBody === "updated event detail";
@@ -231,13 +231,30 @@ const ChatThreadScreen = () => {
       (p) => p.id === item.senderId,
     );
     const senderName = participant?.name ?? "";
-    const initials = senderName
-      .split(" ")
-      .map((w: string) => w[0] ?? "")
-      .slice(0, 2)
-      .join("")
-      .toUpperCase();
+    const firstName = senderName.split(" ")[0] || "";
+    const initials =
+      senderName
+        .split(" ")
+        .map((w: string) => w[0] ?? "")
+        .slice(0, 2)
+        .join("")
+        .toUpperCase() || "?";
     const avatarColor = `hsl(${(item.senderId * 47) % 360}, 55%, 45%)`;
+
+    const prevMessage = index > 0 ? messages[index - 1] : null;
+    const isFirstInRun =
+      !prevMessage || prevMessage.senderId !== item.senderId;
+    const showAvatar = !isOwn && isGroupConversation;
+    const showName = showAvatar && isFirstInRun;
+
+    const timeText = item.pending
+      ? "Sending…"
+      : item.failed
+        ? "Failed. Tap to retry."
+        : new Date(item.createdAt).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          });
 
     const bubble = (
       <View
@@ -247,6 +264,9 @@ const ChatThreadScreen = () => {
           item.failed ? styles.messageBubbleFailed : undefined,
         ]}
       >
+        {showName && firstName ? (
+          <Text style={styles.senderName}>{firstName}</Text>
+        ) : null}
         <Text
           style={[
             styles.messageText,
@@ -265,14 +285,7 @@ const ChatThreadScreen = () => {
                 : styles.messageMetaOther,
           ]}
         >
-          {item.pending
-            ? "Sending…"
-            : item.failed
-              ? "Failed. Tap to retry."
-              : new Date(item.createdAt).toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
+          {timeText}
         </Text>
       </View>
     );
@@ -285,8 +298,6 @@ const ChatThreadScreen = () => {
       bubble
     );
 
-    const showAvatar = !isOwn && isGroupConversation;
-
     return (
       <View
         style={[
@@ -295,14 +306,15 @@ const ChatThreadScreen = () => {
         ]}
       >
         {showAvatar ? (
-          <View style={[styles.avatarCircle, { backgroundColor: avatarColor }]}>
-            <Text style={styles.avatarInitials}>{initials}</Text>
-          </View>
+          isFirstInRun ? (
+            <View style={[styles.avatarCircle, { backgroundColor: avatarColor }]}>
+              <Text style={styles.avatarInitials}>{initials}</Text>
+            </View>
+          ) : (
+            <View style={styles.avatarSpacer} />
+          )
         ) : null}
         <View style={styles.messageBubbleContainer}>
-          {showAvatar && senderName ? (
-            <Text style={styles.senderName}>{senderName}</Text>
-          ) : null}
           {bubbleContent}
         </View>
       </View>
@@ -587,17 +599,26 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontFamily: typography.fontFamilySemiBold,
   },
+  avatarSpacer: {
+    width: 30,
+    marginRight: spacing.xs,
+    flexShrink: 0,
+  },
   senderName: {
-    fontSize: typography.caption,
-    color: colors.subText,
-    fontFamily: typography.fontFamilySemiBold,
+    fontSize: 17,
+    fontFamily: typography.fontFamilyMedium,
+    fontWeight: "500",
+    lineHeight: 22,
+    letterSpacing: -0.5,
+    color: "#000000",
     marginBottom: 2,
-    marginLeft: spacing.xs,
   },
   messageBubble: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    borderRadius: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+    paddingLeft: 16,
+    paddingRight: 16,
+    borderRadius: 12,
   },
   messageBubbleOwn: {
     alignSelf: "flex-end",
@@ -605,15 +626,17 @@ const styles = StyleSheet.create({
   },
   messageBubbleOther: {
     alignSelf: "flex-start",
-    backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
+    backgroundColor: "#F4F4F4",
   },
   messageBubbleFailed: {
     borderColor: colors.accent,
   },
   messageText: {
+    fontSize: 17,
     fontFamily: typography.fontFamilyRegular,
+    fontWeight: "400",
+    lineHeight: 22,
+    letterSpacing: -0.5,
   },
   messageTextOwn: {
     color: colors.buttonText,
@@ -623,7 +646,12 @@ const styles = StyleSheet.create({
   },
   messageMeta: {
     marginTop: 4,
-    fontSize: typography.caption,
+    fontSize: 11,
+    fontFamily: typography.fontFamilyRegular,
+    fontWeight: "400",
+    lineHeight: 11,
+    letterSpacing: -0.3,
+    textAlign: "right",
   },
   messageMetaOwn: {
     color: colors.buttonText,

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -243,7 +243,8 @@ const EventDetailsScreen = () => {
   );
   const goingParticipants = useMemo(() => {
     if (eventConversation?.participants?.length) {
-      return eventConversation.participants;
+      const memberSet = new Set(eventConversation.memberIds ?? []);
+      return eventConversation.participants.filter(p => memberSet.has(p.id));
     }
     return [fallbackHostParticipant];
   }, [eventConversation, fallbackHostParticipant]);
@@ -373,7 +374,10 @@ const EventDetailsScreen = () => {
   // Get confirmed members (excluding host)
   const confirmedMembers = useMemo(() => {
     if (!eventConversation || !user) return [];
-    return eventConversation.participants.filter((p) => p.id !== user.id);
+    const memberSet = new Set(eventConversation.memberIds ?? []);
+    return eventConversation.participants.filter(
+      (p) => p.id !== user.id && memberSet.has(p.id)
+    );
   }, [eventConversation, user]);
 
   // Fetch the user's introduction message when they have a pending request or are a member


### PR DESCRIPTION
## Summary
- **Group chat avatars**: Show sender avatar and first name beside messages in group chats, including for users who have left the conversation and for intro messages following system announcements ("X joined the chat")
- **Report/unblock fix**: The unblock endpoint now also deletes the associated member report and handles the case where only a direct block exists (no report). Repeated unblock correctly returns 404 when already fully cleaned up.

## Changes
- `src/screens/ChatThreadScreen.tsx` — Avatar/name rendering for non-own messages; system messages break sender runs so intro messages get their own avatar
- `src/context/ChatContext.tsx` — Support for sender info on messages
- `src/screens/EventDetailsScreen.tsx` — Related UI adjustments
- `server/chat_hub.go` — Unblock handler: fallback to block check, delete member report on unblock
- `server/repository.go` — Added `DeleteMemberReport` method
- `server/api_integration_test.go` — Updated idempotent unblock test expectation

## Test plan
- [ ] Open a group chat as host where a user has joined — intro message shows avatar and name
- [ ] Consecutive messages from same sender still group correctly (no duplicate avatars)
- [ ] Messages from users who left the conversation show avatar/name
- [ ] Report a member, then unblock — report and block are both cleaned up
- [ ] Second unblock attempt returns 404
- [ ] `npm test` passes (pre-existing failures only)
- [ ] `go test ./...` passes

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)