### PR TITLE
fix: remove intro message from group chat thread

### DIFF
--- a/server/api_integration_test.go
+++ b/server/api_integration_test.go
@@ -1527,7 +1527,7 @@ func TestGroupEventJoinRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("group approval persists intro message in chat history", func(t *testing.T) {
+	t.Run("group approval does NOT insert intro message in chat history", func(t *testing.T) {
 		resp := env.doRequest(t, http.MethodGet, fmt.Sprintf("/api/events/%d/conversations", groupEventID), avaToken, nil)
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -1544,15 +1544,10 @@ func TestGroupEventJoinRequest(t *testing.T) {
 		}
 
 		messages := decodeJSON[messagesResponse](t, resp)
-		found := false
 		for _, msg := range messages.Messages {
 			if msg.Body == "I'd love to join the hike!" {
-				found = true
-				break
+				t.Fatalf("intro message should NOT appear in group chat history")
 			}
-		}
-		if !found {
-			t.Fatalf("expected intro message to be visible in group chat history, messages: %+v", messages.Messages)
 		}
 	})
 }

--- a/server/chat_hub.go
+++ b/server/chat_hub.go
@@ -994,8 +994,10 @@ func (h *ChatHTTPHandler) approveJoin(c *gin.Context) {
 		// subscribe immediately to the newly created private conversation.
 		h.hub.NotifyMembership(convo.ID, event.UserID, "added")
 	}
-	if err := h.emitApprovedIntroMessage(ctx, convo.ID, userID, req.Message); err != nil {
-		log.Printf("emit approved intro message failed: %v", err)
+	if event.GroupType == "Single" {
+		if err := h.emitApprovedIntroMessage(ctx, convo.ID, userID, req.Message); err != nil {
+			log.Printf("emit approved intro message failed: %v", err)
+		}
 	}
 	if event.GroupType == "Group" {
 		h.hub.emitJoinRequestEvent(convo.ID, "approved", view)

--- a/server/repository.go
+++ b/server/repository.go
@@ -2119,18 +2119,6 @@ func (r *EventRepository) ApproveJoinRequest(ctx context.Context, eventID, userI
 		return nil, fmt.Errorf("add conversation member: %w", err)
 	}
 
-	trimmedMessage := strings.TrimSpace(req.Message)
-	if trimmedMessage != "" {
-		// Persist requester intro into the group chat when approval happens.
-		var msg Message
-		var attachmentOut sql.NullString
-		row := tx.QueryRowContext(ctx, insertMessage, convo.ID, userID, trimmedMessage, sql.NullString{}, "sent")
-		if err := row.Scan(&msg.ID, &msg.ConversationID, &msg.SenderID, &msg.Body, &attachmentOut, &msg.DeliveryStatus, &msg.CreatedAt); err != nil {
-			tx.Rollback()
-			return nil, fmt.Errorf("insert approved group intro message: %w", err)
-		}
-	}
-
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit join approval: %w", err)
 	}


### PR DESCRIPTION
## Summary
- For group events, the user's intro message is no longer inserted into the chat history on join approval
- Only the system announcement ("{Name} joined the chat") appears in the group chat
- The intro text remains stored in the join requests table and visible on the pending requests screen
- 1:1 event behavior is unchanged — intro messages still appear as the first chat message

## Changes
- `server/repository.go` — Removed the block that inserts the intro message into the `messages` table for group events
- `server/chat_hub.go` — Guarded `emitApprovedIntroMessage` WebSocket emit to Single events only
- `server/api_integration_test.go` — Updated test to assert intro message is NOT present in group chat history

## Test plan
- [ ] Join a group event with an intro message → after approval, only "{Name} joined the chat" appears in group chat
- [ ] Join a 1:1 event with an intro message → intro message still appears as first chat message
- [ ] Pending requests screen still shows the intro message text
- [ ] `go test ./... -run TestGroupEventJoinRequest` passes
- [ ] `go test ./... -run TestSingleEventJoinRequest` passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)