### PR TITLE
fix: joined/created event count mismatch

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -1,29 +1,32 @@
 package main
 
 import (
-    "database/sql"
-    "fmt"
+	"database/sql"
+	"fmt"
 
-    _ "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 // openDB establishes a SQLite connection with sane defaults for this app.
 func openDB(path string) (*sql.DB, error) {
-    dsn := fmt.Sprintf("file:%s?_foreign_keys=on&_busy_timeout=5000", path)
+	dsn := fmt.Sprintf(
+		"file:%s?_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)",
+		path,
+	)
 
-    conn, err := sql.Open("sqlite", dsn)
-    if err != nil {
-        return nil, fmt.Errorf("open sqlite: %w", err)
-    }
+	conn, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
 
-    conn.SetConnMaxLifetime(0)
-    conn.SetMaxIdleConns(10)
-    conn.SetMaxOpenConns(1)
+	conn.SetConnMaxLifetime(0)
+	conn.SetMaxIdleConns(10)
+	conn.SetMaxOpenConns(1)
 
-    if err := conn.Ping(); err != nil {
-        _ = conn.Close()
-        return nil, fmt.Errorf("ping sqlite: %w", err)
-    }
+	if err := conn.Ping(); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("ping sqlite: %w", err)
+	}
 
-    return conn, nil
+	return conn, nil
 }

--- a/server/repository.go
+++ b/server/repository.go
@@ -667,6 +667,9 @@ func (r *EventRepository) Init(ctx context.Context) error {
 	if err := r.ensureReportedUserIDColumn(ctx); err != nil {
 		return err
 	}
+	if err := r.cleanupOrphanedEventReferences(ctx); err != nil {
+		return err
+	}
 	if err := r.ensureUserProfileColumns(ctx); err != nil {
 		return err
 	}
@@ -1269,6 +1272,49 @@ func (r *EventRepository) cleanupOrphanedSingleEventConversations(ctx context.Co
 	if _, err := r.db.ExecContext(ctx, cleanupQuery); err != nil {
 		return fmt.Errorf("cleanup orphaned single event conversations: %w", err)
 	}
+	return nil
+}
+
+// cleanupOrphanedEventReferences removes legacy rows that still point to
+// deleted events from periods where foreign key enforcement was not active.
+func (r *EventRepository) cleanupOrphanedEventReferences(ctx context.Context) error {
+	const deleteOrphanedConversations = `
+		DELETE FROM conversations
+		WHERE event_id IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1
+			FROM events e
+			WHERE e.id = conversations.event_id
+		);
+	`
+	if _, err := r.db.ExecContext(ctx, deleteOrphanedConversations); err != nil {
+		return fmt.Errorf("cleanup orphaned conversations: %w", err)
+	}
+
+	const deleteOrphanedJoinRequests = `
+		DELETE FROM conversation_join_requests
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM events e
+			WHERE e.id = conversation_join_requests.event_id
+		);
+	`
+	if _, err := r.db.ExecContext(ctx, deleteOrphanedJoinRequests); err != nil {
+		return fmt.Errorf("cleanup orphaned join requests: %w", err)
+	}
+
+	const deleteOrphanedEventReports = `
+		DELETE FROM event_reports
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM events e
+			WHERE e.id = event_reports.event_id
+		);
+	`
+	if _, err := r.db.ExecContext(ctx, deleteOrphanedEventReports); err != nil {
+		return fmt.Errorf("cleanup orphaned event reports: %w", err)
+	}
+
 	return nil
 }
 

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -9,7 +9,7 @@ import {
   View,
 } from "react-native";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import {
   CompositeNavigationProp,
   useNavigation,
@@ -75,15 +75,41 @@ const MenuItem = ({
 
 const ProfileScreen = () => {
   const { user, signOut } = useAuth();
-  const { userEvents } = useEvents();
+  const { events, userEvents } = useEvents();
   const { conversations } = useChat();
   const navigation = useNavigation<ProfileNavigation>();
 
   // Calculate stats
   const hostedCount = userEvents.length;
-  const joinedCount = conversations.filter(
-    (c) => c.eventId && c.createdBy !== user?.id
-  ).length;
+  const joinedCount = useMemo(() => {
+    if (!user) {
+      return 0;
+    }
+
+    const activeEventIDs = new Set<number>();
+    events.forEach((event) => {
+      const eventID = Number(event.id);
+      if (Number.isInteger(eventID) && eventID > 0) {
+        activeEventIDs.add(eventID);
+      }
+    });
+
+    const joinedEventIDs = new Set<number>();
+    conversations.forEach((conversation) => {
+      if (!conversation.eventId || conversation.eventId <= 0) {
+        return;
+      }
+      if (conversation.createdBy === user.id) {
+        return;
+      }
+      if (!activeEventIDs.has(conversation.eventId)) {
+        return;
+      }
+      joinedEventIDs.add(conversation.eventId);
+    });
+
+    return joinedEventIDs.size;
+  }, [conversations, events, user]);
 
   const handleSignOut = useCallback(() => {
     signOut();

--- a/src/screens/__tests__/ProfileScreen.rendering.test.tsx
+++ b/src/screens/__tests__/ProfileScreen.rendering.test.tsx
@@ -162,15 +162,19 @@ describe('ProfileScreen Rendering', () => {
 
     it('should display joined events count', () => {
       setupMocks({
+        eventsOverrides: {
+          events: [mockEvents[0]],
+          userEvents: [],
+        },
         chatOverrides: {
           conversations: [
             { ...mockConversations[0], eventId: 1, createdBy: 2 }, // Joined event
           ],
         },
       });
-      const { getByText } = render(<ProfileScreen />);
+      const { getAllByText, getByText } = render(<ProfileScreen />);
 
-      expect(getByText('1')).toBeTruthy();
+      expect(getAllByText('1').length).toBe(1);
       expect(getByText('Joined')).toBeTruthy();
     });
   });
@@ -345,7 +349,7 @@ describe('ProfileScreen Rendering', () => {
   describe('Stats Display', () => {
     it('should show zero counts when no events', () => {
       setupMocks({
-        eventsOverrides: { userEvents: [] },
+        eventsOverrides: { events: [], userEvents: [] },
         chatOverrides: { conversations: [] },
       });
       const { getAllByText } = render(<ProfileScreen />);
@@ -355,20 +359,45 @@ describe('ProfileScreen Rendering', () => {
       expect(zeros.length).toBe(2);
     });
 
-    it('should correctly calculate joined count excluding own events', () => {
+    it('should correctly calculate joined count excluding own and duplicate event conversations', () => {
       setupMocks({
         authOverrides: { user: mockUsers[0] }, // id: 1
+        eventsOverrides: {
+          events: [mockEvents[0], mockEvents[1]], // Active event IDs: 1, 2
+          userEvents: [],
+        },
         chatOverrides: {
           conversations: [
             { ...mockConversations[0], eventId: 1, createdBy: 1 }, // Own event - not counted
             { ...mockConversations[1], eventId: 2, createdBy: 2 }, // Joined event - counted
+            { ...mockConversations[1], id: 3, eventId: 2, createdBy: 3 }, // Same event - deduped
+            { ...mockConversations[1], id: 4, eventId: 999, createdBy: 2 }, // Stale event - ignored
           ],
         },
       });
-      const { getByText } = render(<ProfileScreen />);
+      const { getAllByText, getByText } = render(<ProfileScreen />);
 
-      // Should show 1 for joined (only event from user 2)
+      // Should show 1 joined event after own-event filtering + dedupe + stale filtering.
+      expect(getAllByText('1').length).toBe(1);
       expect(getByText('Joined')).toBeTruthy();
+    });
+
+    it('should ignore stale conversation event IDs missing from active events', () => {
+      setupMocks({
+        eventsOverrides: {
+          events: [mockEvents[0]],
+          userEvents: [],
+        },
+        chatOverrides: {
+          conversations: [
+            { ...mockConversations[0], eventId: 999, createdBy: 2 }, // Missing from active events
+          ],
+        },
+      });
+      const { getAllByText } = render(<ProfileScreen />);
+
+      // Hosted and Joined should both remain 0.
+      expect(getAllByText('0').length).toBe(2);
     });
   });
 });


### PR DESCRIPTION
Closes #21

### What changed
- Fixed SQLite FK pragma config.
- Added startup cleanup for orphaned event references.
- Fixed Profile Joined count to use active events + dedupe.
- Added ProfileScreen rendering test coverage.