### PR TITLE
Fix stuck refresh spinner and stale list updates across Discover/Chat/Join Requests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -174,6 +174,28 @@ jest.mock('@ptomasroos/react-native-multi-slider', () => {
   };
 });
 
+// Mock expo-blur
+jest.mock('expo-blur', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    __esModule: true,
+    BlurView: ({ children, ...props }: any) => React.createElement(View, props, children),
+  };
+});
+
+// Mock expo-linear-gradient
+jest.mock('expo-linear-gradient', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  return {
+    __esModule: true,
+    LinearGradient: ({ children, ...props }: any) => React.createElement(View, props, children),
+  };
+});
+
 // Mock react-native-keyboard-aware-scroll-view
 jest.mock('react-native-keyboard-aware-scroll-view', () => {
   const React = require('react');

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -118,6 +118,21 @@ interface ChatContextValue {
 const ChatContext = createContext<ChatContextValue | undefined>(undefined);
 
 const WS_PATH = "/api/ws";
+const REFRESH_TIMEOUT_MS = 10_000;
+
+const createRequestTimeout = (timeoutMs: number) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeoutId),
+  };
+};
+
+const isAbortError = (err: unknown) =>
+  err instanceof Error && err.name === "AbortError";
 
 const sortConversationsByActivity = (items: ChatConversation[]) => {
   return [...items].sort((a, b) => {
@@ -204,6 +219,8 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const tokenRef = useRef<string | null>(null);
   const authFetchRef = useRef(authFetch);
   const refreshSessionSilentlyRef = useRef(refreshSessionSilently);
+  const conversationsRefreshRequestIdRef = useRef(0);
+  const joinRequestsRefreshRequestIdRef = useRef<Record<number, number>>({});
 
   useEffect(() => {
     activeConversationRef.current = activeConversationId;
@@ -364,18 +381,25 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
     if (!activeToken) {
       return;
     }
+    const requestId = conversationsRefreshRequestIdRef.current + 1;
+    conversationsRefreshRequestIdRef.current = requestId;
     setIsRefreshingConversations(true);
+    const timeout = createRequestTimeout(REFRESH_TIMEOUT_MS);
     try {
       const response = await fetchClient(`${API_BASE_URL}/api/conversations`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${activeToken}`,
         },
+        signal: timeout.signal,
       });
       if (!response.ok) {
         throw new Error("Unable to load conversations");
       }
       const payload = (await response.json()) as ConversationsResponse;
+      if (requestId !== conversationsRefreshRequestIdRef.current) {
+        return;
+      }
       setError(null);
       const normalized = (payload.conversations ?? []).map((conversation) => {
         const participants = conversation.participants ?? [];
@@ -463,10 +487,20 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         setActiveConversationId(null);
       }
     } catch (err) {
+      if (requestId !== conversationsRefreshRequestIdRef.current) {
+        return;
+      }
       console.error("Failed to load conversations", err);
-      setError((err as Error).message);
+      if (isAbortError(err)) {
+        setError("Unable to load conversations");
+      } else {
+        setError((err as Error).message);
+      }
     } finally {
-      setIsRefreshingConversations(false);
+      timeout.clear();
+      if (requestId === conversationsRefreshRequestIdRef.current) {
+        setIsRefreshingConversations(false);
+      }
     }
   }, [token, user]);
 
@@ -488,6 +522,9 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       }
       const includeApproved = options?.includeApproved === true;
       const query = includeApproved ? "?include_approved=1" : "";
+      const requestId = (joinRequestsRefreshRequestIdRef.current[eventId] ?? 0) + 1;
+      joinRequestsRefreshRequestIdRef.current[eventId] = requestId;
+      const timeout = createRequestTimeout(REFRESH_TIMEOUT_MS);
       try {
         const response = await fetchClient(
           `${API_BASE_URL}/api/events/${eventId}/chat/requests${query}`,
@@ -495,10 +532,14 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
             headers: {
               Authorization: `Bearer ${activeToken}`,
             },
+            signal: timeout.signal,
           },
         );
         if (response.status === 404) {
           // Event may have been deleted while polling host requests; treat as empty.
+          if (joinRequestsRefreshRequestIdRef.current[eventId] !== requestId) {
+            return;
+          }
           setJoinRequestsByConversation((prev) => ({
             ...prev,
             [conversationId]: [],
@@ -516,14 +557,22 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
           requests?: any[];
         };
         const normalized = (payload.requests ?? []).map(normalizeJoinRequest);
+        if (joinRequestsRefreshRequestIdRef.current[eventId] !== requestId) {
+          return;
+        }
         setJoinRequestsByConversation((prev) => ({
           ...prev,
           [conversationId]: normalized,
           [-eventId]: normalized,
         }));
       } catch (err) {
+        if (joinRequestsRefreshRequestIdRef.current[eventId] !== requestId) {
+          return;
+        }
         console.error("Failed to load join requests", err);
         throw err;
+      } finally {
+        timeout.clear();
       }
     },
     [normalizeJoinRequest],

--- a/src/context/EventsContext.tsx
+++ b/src/context/EventsContext.tsx
@@ -130,6 +130,22 @@ interface EventMeta {
   badgeLabel?: string;
 }
 
+const REFRESH_TIMEOUT_MS = 10_000;
+
+const createRequestTimeout = (timeoutMs: number) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeoutId),
+  };
+};
+
+const isAbortError = (err: unknown) =>
+  err instanceof Error && err.name === "AbortError";
+
 const formatAudience = (gender: string, minAge: number, maxAge: number) => {
   const genderLabel = gender.toLowerCase() === "any" ? "Any gender" : gender;
   return `${genderLabel}, ${minAge} to ${maxAge} years`;
@@ -292,6 +308,8 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
   const [reportedEventIds, setReportedEventIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const eventsRequestIdRef = useRef(0);
+  const requestedEventsRequestIdRef = useRef(0);
   const resetRequestedEventIds = useCallback(() => {
     setRequestedEventIds((prev) => {
       if (prev.size === 0) {
@@ -307,13 +325,18 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
   }, [authFetch]);
 
   const refreshEvents = useCallback(async () => {
+    const requestId = eventsRequestIdRef.current + 1;
+    eventsRequestIdRef.current = requestId;
     setIsLoading(true);
     setError(null);
     const fetchClient = authFetchRef.current;
     if (!fetchClient) {
-      setIsLoading(false);
+      if (requestId === eventsRequestIdRef.current) {
+        setIsLoading(false);
+      }
       return;
     }
+    const timeout = createRequestTimeout(REFRESH_TIMEOUT_MS);
     try {
       const response = await fetchClient(`${API_BASE_URL}/api/events`, {
         headers: token
@@ -321,6 +344,7 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
               Authorization: `Bearer ${token}`,
             }
           : undefined,
+        signal: timeout.signal,
       });
       if (!response.ok) {
         throw new Error(`Request failed with status ${response.status}`);
@@ -331,16 +355,31 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
         .map((event) => mapApiEvent(event, metaRef.current[String(event.id)]))
         .filter((event) => isUpcomingEvent(event.eventDate, event.time, event.scheduledAt))
         .sort(sortEventsBySchedule);
+      if (requestId !== eventsRequestIdRef.current) {
+        return;
+      }
       setEvents(nextEvents);
     } catch (err) {
+      if (requestId !== eventsRequestIdRef.current) {
+        return;
+      }
       console.error("Failed to fetch events", err);
-      setError("Unable to load events. Pull to refresh.");
+      if (isAbortError(err)) {
+        setError("Unable to load events. Request timed out.");
+      } else {
+        setError("Unable to load events. Pull to refresh.");
+      }
     } finally {
-      setIsLoading(false);
+      timeout.clear();
+      if (requestId === eventsRequestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [token]);
 
   const refreshRequestedEvents = useCallback(async () => {
+    const requestId = requestedEventsRequestIdRef.current + 1;
+    requestedEventsRequestIdRef.current = requestId;
     if (!user || !token) {
       resetRequestedEventIds();
       return;
@@ -350,6 +389,7 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
       resetRequestedEventIds();
       return;
     }
+    const timeout = createRequestTimeout(REFRESH_TIMEOUT_MS);
     try {
       const response = await fetchClient(`${API_BASE_URL}/api/chat/requests/me`, {
         headers: token
@@ -357,10 +397,14 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
               Authorization: `Bearer ${token}`,
             }
           : undefined,
+        signal: timeout.signal,
       });
 
       if (response.status === 401) {
         // authFetch already attempted refresh; treat remaining 401 as session transition.
+        if (requestId !== requestedEventsRequestIdRef.current) {
+          return;
+        }
         resetRequestedEventIds();
         return;
       }
@@ -378,10 +422,18 @@ export const EventsProvider = ({ children }: { children: ReactNode }) => {
           ids.add(String(idValue));
         }
       });
+      if (requestId !== requestedEventsRequestIdRef.current) {
+        return;
+      }
       setRequestedEventIds(ids);
     } catch (err) {
+      if (requestId !== requestedEventsRequestIdRef.current) {
+        return;
+      }
       console.error("Failed to fetch requested events", err);
       resetRequestedEventIds();
+    } finally {
+      timeout.clear();
     }
   }, [resetRequestedEventIds, token, user]);
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -104,6 +104,7 @@ const HomeScreen = () => {
   const tabBarHeight = useBottomTabBarHeight();
   const [sortMode, setSortMode] = useState<SortMode>("upcoming");
   const hasLoadedOnce = useRef(false);
+  const [isPullRefreshing, setIsPullRefreshing] = useState(false);
   const [showReportedBadge, setShowReportedBadge] = useState(false);
   const [showEventDeletedBadge, setShowEventDeletedBadge] = useState(false);
   const [showEventLeftBadge, setShowEventLeftBadge] = useState(false);
@@ -183,21 +184,25 @@ const HomeScreen = () => {
   const showAllEventsError = !!error && !isLoading && sections.length === 0;
   const showAllEventsEmpty = !isLoading && sections.length === 0 && !error;
 
+  const refreshAll = useCallback(
+    async () => Promise.all([refreshEvents(), refreshRequestedEvents()]),
+    [refreshEvents, refreshRequestedEvents],
+  );
+
   const handleRefresh = useCallback(() => {
-    Promise.all([refreshEvents(), refreshRequestedEvents()]).catch(
-      () => undefined,
-    );
-  }, [refreshEvents, refreshRequestedEvents]);
+    setIsPullRefreshing(true);
+    refreshAll()
+      .catch(() => undefined)
+      .finally(() => setIsPullRefreshing(false));
+  }, [refreshAll]);
 
   useEffect(() => {
     if (!isFocused) {
       return;
     }
-    Promise.all([refreshEvents(), refreshRequestedEvents()]).catch(
-      () => undefined,
-    );
+    refreshAll().catch(() => undefined);
     return;
-  }, [isFocused, refreshEvents, refreshRequestedEvents]);
+  }, [isFocused, refreshAll]);
 
   const renderSectionHeader = ({ section }: { section: EventSection }) => (
     <Text style={styles.sectionHeader}>{section.title}</Text>
@@ -248,7 +253,7 @@ const HomeScreen = () => {
           contentContainerStyle={styles.centerContent}
           refreshControl={
             <RefreshControl
-              refreshing={isLoading}
+              refreshing={isPullRefreshing}
               onRefresh={handleRefresh}
               tintColor={colors.primary}
             />
@@ -280,7 +285,7 @@ const HomeScreen = () => {
           ListFooterComponent={<View style={styles.footerSpacing} />}
           refreshControl={
             <RefreshControl
-              refreshing={isLoading}
+              refreshing={isPullRefreshing}
               onRefresh={handleRefresh}
               tintColor={colors.primary}
             />

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -76,19 +76,29 @@ const JoinRequestsScreen = () => {
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
   const [isRemovingMember, setIsRemovingMember] = useState(false);
 
-  const handleRefresh = useCallback(() => {
-    setIsRefreshing(true);
-    refreshJoinRequests(conversationId, eventId, {
-      includeApproved: is1to1Mode,
-    })
-      .catch(() => undefined)
-      .finally(() => setIsRefreshing(false));
+  const loadRequests = useCallback(async (showRefreshing: boolean) => {
+    if (showRefreshing) {
+      setIsRefreshing(true);
+    }
+    try {
+      await refreshJoinRequests(conversationId, eventId, {
+        includeApproved: is1to1Mode,
+      });
+    } finally {
+      if (showRefreshing) {
+        setIsRefreshing(false);
+      }
+    }
   }, [conversationId, eventId, refreshJoinRequests, is1to1Mode]);
+
+  const handleRefresh = useCallback(() => {
+    loadRequests(true).catch(() => undefined);
+  }, [loadRequests]);
 
   useFocusEffect(
     useCallback(() => {
-      handleRefresh();
-    }, [handleRefresh]),
+      loadRequests(false).catch(() => undefined);
+    }, [loadRequests]),
   );
 
   const handleAction = useCallback(

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   View,
 } from "react-native";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   useFocusEffect,
   useNavigation,
@@ -45,6 +45,7 @@ const MessagesScreen = () => {
   } = useChat();
   const { events, isEventReported } = useEvents();
   const insets = useSafeAreaInsets();
+  const [isPullRefreshing, setIsPullRefreshing] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -56,6 +57,13 @@ const MessagesScreen = () => {
       return undefined;
     }, [refreshConversations, user]),
   );
+
+  const handleRefresh = useCallback(() => {
+    setIsPullRefreshing(true);
+    refreshConversations()
+      .catch(() => undefined)
+      .finally(() => setIsPullRefreshing(false));
+  }, [refreshConversations]);
 
   const displayConversations = useMemo(() => {
     if (!user) return conversations;
@@ -236,8 +244,8 @@ const MessagesScreen = () => {
           }
           refreshControl={
             <RefreshControl
-              refreshing={isRefreshingConversations}
-              onRefresh={refreshConversations}
+              refreshing={isPullRefreshing}
+              onRefresh={handleRefresh}
               tintColor={colors.primary}
             />
           }

--- a/src/screens/__tests__/HomeScreen.rendering.test.tsx
+++ b/src/screens/__tests__/HomeScreen.rendering.test.tsx
@@ -28,6 +28,13 @@ let mockChatValue = { conversations: mockConversations };
 jest.mock('@context/AuthContext', () => ({ useAuth: () => mockAuthValue }));
 jest.mock('@context/EventsContext', () => ({ useEvents: () => mockEventsValue }));
 jest.mock('@context/ChatContext', () => ({ useChat: () => mockChatValue }));
+jest.mock('@react-navigation/bottom-tabs', () => {
+  const actual = jest.requireActual('@react-navigation/bottom-tabs');
+  return {
+    ...actual,
+    useBottomTabBarHeight: () => 0,
+  };
+});
 
 jest.mock('@components/EmptyState', () => {
   const { View, Text } = require('react-native');
@@ -169,11 +176,11 @@ describe('HomeScreen Rendering', () => {
       expect(mockEventsValue.refreshEvents).toHaveBeenCalled();
     });
 
-    it('shows refreshing state during refresh', () => {
+    it('does not tie pull-refresh spinner to background loading', () => {
       mockEventsValue.isLoading = true;
       const { UNSAFE_getByType } = render(<HomeScreen />);
       const { SectionList } = require('react-native');
-      expect(UNSAFE_getByType(SectionList).props.refreshControl.props.refreshing).toBe(true);
+      expect(UNSAFE_getByType(SectionList).props.refreshControl.props.refreshing).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- decouple pull-to-refresh UI from focus/app-resume auto refresh in Discover, Chat list, and Join Requests
- add request timeout guards to events/conversations/join-requests refresh paths
- ignore stale/out-of-order refresh responses so older results cannot overwrite newer list state
- keep existing list visible during background refresh and avoid stuck top spinner offset

## Testing
- npm test -- --runTestsByPath src/screens/__tests__/HomeScreen.rendering.test.tsx src/screens/__tests__/MessagesScreen.rendering.test.tsx src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx src/context/__tests__/ChatContext.test.tsx src/context/__tests__/EventsContext.test.ts --watchman=false

Fixes #14