### PR TITLE
refactor: navigation and animation improvements

### DIFF
--- a/src/components/AnimatedPager.tsx
+++ b/src/components/AnimatedPager.tsx
@@ -1,0 +1,247 @@
+import React, { useLayoutEffect, useEffect, useRef } from 'react';
+import {
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withTiming,
+  cancelAnimation,
+  runOnJS,
+  Easing,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import * as Haptics from 'expo-haptics';
+import { colors } from '@theme/colors';
+
+const SWIPE_DISTANCE = 50;
+const SWIPE_VELOCITY = 500; // px/s — meaningful flick threshold
+// Tap-triggered slide: fixed timing like PagerView.setPage()
+const TAP_TIMING = { duration: 280, easing: Easing.out(Easing.cubic) } as const;
+// Cancelled swipe snapback
+const SNAPBACK_TIMING = { duration: 180, easing: Easing.out(Easing.cubic) } as const;
+// Committed swipe settle: spring driven by finger velocity, no overshoot
+const COMMIT_SPRING = { mass: 1, stiffness: 300, damping: 40, overshootClamping: true } as const;
+
+type AnimatedPagerProps = {
+  selectedIndex: number;
+  onPageChange: (index: number) => void;
+  onPendingIndexChange?: (index: number) => void;
+  pageOffsetSV?: SharedValue<number>;
+  children: React.ReactNode;
+  style?: ViewStyle;
+  swipeEnabled?: boolean;
+};
+
+// Supports up to 4 pages. Shared values must be created unconditionally.
+const AnimatedPager = ({
+  selectedIndex,
+  onPageChange,
+  onPendingIndexChange,
+  pageOffsetSV,
+  children,
+  style,
+  swipeEnabled = true,
+}: AnimatedPagerProps) => {
+  const { width } = useWindowDimensions();
+  const childArray = React.Children.toArray(children);
+  const pageCount = childArray.length;
+  const prevIndex = useRef(selectedIndex);
+
+  const onPageChangeRef = useRef(onPageChange);
+  const onPendingIndexChangeRef = useRef(onPendingIndexChange);
+  useEffect(() => { onPageChangeRef.current = onPageChange; }, [onPageChange]);
+  useEffect(() => { onPendingIndexChangeRef.current = onPendingIndexChange; }, [onPendingIndexChange]);
+
+  // Prevents useLayoutEffect from re-running the slide animation when selectedIndex
+  // updates as a result of a swipe commit (animation already done by gesture handler)
+  const swipeCommittedRef = useRef(false);
+
+  // Each page has a single translateX shared value
+  const slide0 = useSharedValue(0 === selectedIndex ? 0 : 0 < selectedIndex ? -width : width);
+  const slide1 = useSharedValue(1 === selectedIndex ? 0 : 1 < selectedIndex ? -width : width);
+  const slide2 = useSharedValue(2 === selectedIndex ? 0 : 2 < selectedIndex ? -width : width);
+  const slide3 = useSharedValue(3 === selectedIndex ? 0 : 3 < selectedIndex ? -width : width);
+  const slides = [slide0, slide1, slide2, slide3];
+
+  const selectedIndexSV = useSharedValue(selectedIndex);
+  const widthSV = useSharedValue(width);
+  const isAnimating = useSharedValue(false);
+  const dragFrom = useSharedValue(-1);
+  const dragTo = useSharedValue(-1);
+
+  useEffect(() => { selectedIndexSV.value = selectedIndex; }, [selectedIndex]);
+  useEffect(() => { widthSV.value = width; }, [width]);
+
+  const notifyPageChange = (index: number) => {
+    swipeCommittedRef.current = true;
+    onPageChangeRef.current(index);
+  };
+  const notifyPendingChange = (index: number) => { onPendingIndexChangeRef.current?.(index); };
+  const triggerHaptic = () => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); };
+
+  const pan = Gesture.Pan()
+    .enabled(swipeEnabled)
+    .activeOffsetX([-10, 10])
+    .failOffsetY([-25, 25])
+    .onUpdate((e) => {
+      if (isAnimating.value) return;
+      const dx = e.translationX;
+      const current = selectedIndexSV.value;
+      const w = widthSV.value;
+
+      if (dragFrom.value === -1) {
+        if (dx < 0 && current < pageCount - 1) {
+          dragFrom.value = current;
+          dragTo.value = current + 1;
+          runOnJS(notifyPendingChange)(current + 1);
+        } else if (dx > 0 && current > 0) {
+          dragFrom.value = current;
+          dragTo.value = current - 1;
+          runOnJS(notifyPendingChange)(current - 1);
+        } else {
+          return;
+        }
+      }
+
+      const from = dragFrom.value;
+      const to = dragTo.value;
+      // 1:1 finger tracking — both pages move together like a belt
+      slides[from].value = dx;
+      slides[to].value = to > from ? dx + w : dx - w;
+
+      // Continuous page offset for filter tracking
+      if (pageOffsetSV) {
+        const fraction = Math.max(0, Math.min(1, Math.abs(dx) / w));
+        pageOffsetSV.value = from + (to - from) * fraction;
+      }
+    })
+    .onEnd((e) => {
+      const from = dragFrom.value;
+      const to = dragTo.value;
+      dragFrom.value = -1;
+      dragTo.value = -1;
+      if (from === -1) return;
+
+      const dx = e.translationX;
+      const vx = e.velocityX;
+      const w = widthSV.value;
+      const toIsNext = to > from;
+      const committed = toIsNext
+        ? dx < -SWIPE_DISTANCE || vx < -SWIPE_VELOCITY
+        : dx > SWIPE_DISTANCE || vx > SWIPE_VELOCITY;
+
+      if (committed) {
+        isAnimating.value = true;
+        runOnJS(triggerHaptic)();
+        selectedIndexSV.value = to;
+
+        if (pageOffsetSV) {
+          pageOffsetSV.value = withTiming(to, TAP_TIMING);
+        }
+        // Spring with finger velocity — carries momentum naturally, no overshoot
+        slides[from].value = withSpring(toIsNext ? -w : w, { ...COMMIT_SPRING, velocity: vx });
+        slides[to].value = withSpring(0, { ...COMMIT_SPRING, velocity: vx }, (finished) => {
+          isAnimating.value = false;
+          if (finished) {
+            runOnJS(notifyPageChange)(to);
+          }
+        });
+      } else {
+        // Not committed — snap back with timing
+        if (pageOffsetSV) {
+          pageOffsetSV.value = withTiming(from, SNAPBACK_TIMING);
+        }
+        runOnJS(notifyPendingChange)(from);
+        slides[from].value = withTiming(0, SNAPBACK_TIMING);
+        slides[to].value = withTiming(toIsNext ? w : -w, SNAPBACK_TIMING);
+      }
+    })
+    .onFinalize((_, success) => {
+      if (!success) {
+        const from = dragFrom.value;
+        const to = dragTo.value;
+        dragFrom.value = -1;
+        dragTo.value = -1;
+        if (from === -1) return;
+        const w = widthSV.value;
+        if (pageOffsetSV) {
+          pageOffsetSV.value = withTiming(from, SNAPBACK_TIMING);
+        }
+        runOnJS(notifyPendingChange)(from);
+        slides[from].value = withTiming(0, SNAPBACK_TIMING);
+        slides[to].value = withTiming(to > from ? w : -w, SNAPBACK_TIMING);
+      }
+    });
+
+  // Tap-triggered: clean synchronized slide from edge, same as PagerView.setPage()
+  useLayoutEffect(() => {
+    const from = prevIndex.current;
+    const to = selectedIndex;
+    prevIndex.current = to;
+    if (from === to) return;
+
+    // Swipe already animated the pages — just sync the ref, skip the tap transition
+    if (swipeCommittedRef.current) {
+      swipeCommittedRef.current = false;
+      return;
+    }
+
+    const toIsRight = to > from;
+
+    cancelAnimation(slides[to]);
+    cancelAnimation(slides[from]);
+
+    // Filter snaps instantly on tap — only tracks smoothly during swipes
+    if (pageOffsetSV) {
+      pageOffsetSV.value = to;
+    }
+
+    // Start incoming page from full off-screen edge
+    slides[to].value = toIsRight ? width : -width;
+
+    isAnimating.value = true;
+    slides[to].value = withTiming(0, TAP_TIMING, (finished) => {
+      isAnimating.value = false;
+      if (finished) {
+        slides[from].value = toIsRight ? -width : width;
+      }
+    });
+    slides[from].value = withTiming(toIsRight ? -width : width, TAP_TIMING);
+  }, [selectedIndex, width]);
+
+  const animStyle0 = useAnimatedStyle(() => ({ transform: [{ translateX: slide0.value }] }));
+  const animStyle1 = useAnimatedStyle(() => ({ transform: [{ translateX: slide1.value }] }));
+  const animStyle2 = useAnimatedStyle(() => ({ transform: [{ translateX: slide2.value }] }));
+  const animStyle3 = useAnimatedStyle(() => ({ transform: [{ translateX: slide3.value }] }));
+  const animStyles = [animStyle0, animStyle1, animStyle2, animStyle3];
+
+  return (
+    <GestureDetector gesture={pan}>
+      <View style={[styles.container, style]}>
+        {childArray.map((child, index) => (
+          <Animated.View
+            key={index}
+            style={[StyleSheet.absoluteFill, animStyles[index], { backgroundColor: colors.background }]}
+          >
+            {child}
+          </Animated.View>
+        ))}
+      </View>
+    </GestureDetector>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+});
+
+export default AnimatedPager;

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,7 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
-    Animated,
-    Easing,
     Keyboard,
     Modal,
     Platform,
@@ -10,11 +8,20 @@ import {
     Text,
     View,
 } from "react-native";
+import Animated, {
+    useSharedValue,
+    useAnimatedStyle,
+    withSpring,
+    withTiming,
+    runOnJS,
+    Easing,
+} from "react-native-reanimated";
 
 import { Feather } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Haptics from "expo-haptics";
 
+import { Springs } from "@theme/springs";
 import styles from "./BottomSheetModal.styles";
 
 export type BottomSheetModalProps = {
@@ -28,92 +35,76 @@ export type BottomSheetModalProps = {
 const SLIDE_DISTANCE = 500;
 const BASE_PADDING_BOTTOM = 8;
 
+// Bezier approximation of iOS UIViewAnimationCurveKeyboard
+const IOS_KEYBOARD_EASING = Easing.bezier(0.36, 0.66, 0.04, 1);
+
 const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModalProps) => {
     const { bottom: safeBottom } = useSafeAreaInsets();
     const basePadding = BASE_PADDING_BOTTOM + safeBottom;
 
-    const slideAnim = useRef(new Animated.Value(SLIDE_DISTANCE)).current;
-    const backdropAnim = useRef(new Animated.Value(0)).current;
-    // Controls sheet's paddingBottom — grows to push content above the keyboard
-    // while the sheet itself stays anchored to the screen bottom (hidden behind keyboard)
-    const keyboardPaddingAnim = useRef(new Animated.Value(basePadding)).current;
+    const slideAnim = useSharedValue(SLIDE_DISTANCE);
+    const backdropAnim = useSharedValue(0);
+    const keyboardPaddingAnim = useSharedValue(basePadding);
     const [modalVisible, setModalVisible] = useState(false);
     const hasBeenVisible = useRef(false);
+
+    const sheetStyle = useAnimatedStyle(() => ({
+        transform: [{ translateY: slideAnim.value }],
+    }));
+    const backdropStyle = useAnimatedStyle(() => ({
+        opacity: backdropAnim.value,
+    }));
+    const keyboardStyle = useAnimatedStyle(() => ({
+        paddingBottom: keyboardPaddingAnim.value,
+    }));
+
+    const startOpenAnimation = useCallback(() => {
+        slideAnim.value = SLIDE_DISTANCE;
+        backdropAnim.value = 0;
+        keyboardPaddingAnim.value = basePadding;
+        slideAnim.value = withSpring(0, Springs.bouncyUp);
+        backdropAnim.value = withTiming(1, { duration: 100, easing: Easing.out(Easing.cubic) });
+    }, [basePadding]);
 
     useEffect(() => {
         if (visible) {
             hasBeenVisible.current = true;
             setModalVisible(true);
-            slideAnim.setValue(SLIDE_DISTANCE);
-            backdropAnim.setValue(0);
-            keyboardPaddingAnim.setValue(basePadding);
-
-            Animated.parallel([
-                Animated.spring(slideAnim, {
-                    toValue: 0,
-                    tension: 280,
-                    friction: 26,
-                    useNativeDriver: true,
-                }),
-                Animated.timing(backdropAnim, {
-                    toValue: 1,
-                    duration: 320,
-                    easing: Easing.out(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-            ]).start();
+            // Animation starts in onShow, after the modal content is rendered
         } else if (hasBeenVisible.current) {
-            Animated.parallel([
-                Animated.timing(slideAnim, {
-                    toValue: SLIDE_DISTANCE,
-                    duration: 260,
-                    easing: Easing.in(Easing.cubic),
-                    useNativeDriver: true,
-                }),
-                Animated.timing(backdropAnim, {
-                    toValue: 0,
-                    duration: 220,
-                    easing: Easing.in(Easing.ease),
-                    useNativeDriver: true,
-                }),
-            ]).start(() => setModalVisible(false));
+            slideAnim.value = withSpring(SLIDE_DISTANCE, Springs.snappy, (finished) => {
+                if (finished) runOnJS(setModalVisible)(false);
+            });
+            backdropAnim.value = withTiming(0, { duration: 120, easing: Easing.in(Easing.ease) });
         }
-    }, [visible, slideAnim, backdropAnim, keyboardPaddingAnim]);
+    }, [visible]);
 
     useEffect(() => {
         const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
         const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
 
-        // Bezier approximation of iOS UIViewAnimationCurveKeyboard:
-        // fast initial velocity, very short settle — matches the system keyboard spring.
-        const IOS_KEYBOARD_CURVE = Easing.bezier(0.36, 0.66, 0.04, 1);
-
         const showSub = Keyboard.addListener(showEvent, (event) => {
-            Animated.timing(keyboardPaddingAnim, {
-                toValue: event.endCoordinates.height + 16,
+            keyboardPaddingAnim.value = withTiming(event.endCoordinates.height + 16, {
                 duration: event.duration || 250,
-                easing: IOS_KEYBOARD_CURVE,
-                useNativeDriver: false,
-            }).start();
+                easing: IOS_KEYBOARD_EASING,
+            });
         });
 
         const hideSub = Keyboard.addListener(hideEvent, (event) => {
-            Animated.timing(keyboardPaddingAnim, {
-                toValue: basePadding,
+            keyboardPaddingAnim.value = withTiming(basePadding, {
                 duration: (event as any).duration || 250,
-                easing: IOS_KEYBOARD_CURVE,
-                useNativeDriver: false,
-            }).start();
+                easing: IOS_KEYBOARD_EASING,
+            });
         });
 
         return () => {
             showSub.remove();
             hideSub.remove();
         };
-    }, [keyboardPaddingAnim]);
+    }, [basePadding]);
 
     return (
-        <Modal visible={modalVisible} transparent animationType="none" statusBarTranslucent>
+        <Modal visible={modalVisible} transparent animationType="none" statusBarTranslucent onShow={startOpenAnimation}>
             {/* Full-screen Pressable handles backdrop dismiss */}
             <Pressable
                 style={StyleSheet.absoluteFill}
@@ -123,7 +114,7 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
             >
                 {/* Dim overlay — visual only, no touch */}
                 <Animated.View
-                    style={[StyleSheet.absoluteFill, styles.backdrop, { opacity: backdropAnim }]}
+                    style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
                     pointerEvents="none"
                 />
 
@@ -132,12 +123,13 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
                     preventing them from bubbling up to the backdrop Pressable.
                     Child buttons are deeper so they still claim touches first. */}
                 <Animated.View
-                    style={[styles.sheet, { transform: [{ translateY: slideAnim }] }]}
+                    style={[styles.sheet, sheetStyle]}
                     testID="bottom-sheet-modal"
                     onStartShouldSetResponder={() => true}
                 >
-                    {/* JS-driver paddingBottom must be a separate node from native-driver transform */}
-                    <Animated.View style={{ paddingBottom: keyboardPaddingAnim }}>
+                    {/* Keyboard padding on a separate node since layout props
+                        can't share the same Animated.View as transform. */}
+                    <Animated.View style={keyboardStyle}>
                         {title !== undefined && (
                             <View style={styles.header}>
                                 <Text style={styles.title}>{title}</Text>

--- a/src/components/CoverPickerModal.styles.ts
+++ b/src/components/CoverPickerModal.styles.ts
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
         backgroundColor: "transparent",
     },
     optionRingSelected: {
-        backgroundColor: "rgba(0, 0, 0, 0.15)",
+        backgroundColor: "#000000",
     },
     option: {
         flex: 1,

--- a/src/components/CoverPickerModal.tsx
+++ b/src/components/CoverPickerModal.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Dimensions, FlatList, Pressable, View } from "react-native";
+import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import * as Haptics from "expo-haptics";
-
 import { BlurView } from "expo-blur";
 
 import { COVER_OPTIONS, CoverKey } from "@constants/covers";
@@ -44,7 +43,7 @@ const CoverPickerModal: React.FC<CoverPickerModalProps> = ({
                                 <Pressable
                                     style={styles.option}
                                     onPress={() => {
-                                        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+                                        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                                         onSelect(item.key);
                                     }}
                                 >

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { ComponentType, memo } from 'react';
 import { Image, ImageSourcePropType, Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { SvgProps } from 'react-native-svg';
 
 import CreateEventIllustration from '@assets/create-event.svg';
@@ -48,12 +49,12 @@ const EmptyState = ({
       {(actionLabel || secondaryActionLabel) ? (
         <View style={styles.buttonContainer}>
           {secondaryActionLabel ? (
-            <Pressable style={styles.secondaryButton} onPress={onSecondaryActionPress}>
+            <Pressable style={styles.secondaryButton} onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onSecondaryActionPress?.(); }}>
               <Text style={styles.secondaryButtonText}>{secondaryActionLabel}</Text>
             </Pressable>
           ) : null}
           {actionLabel ? (
-            <Pressable style={styles.button} onPress={onActionPress} testID="empty-state-action">
+            <Pressable style={styles.button} onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onActionPress?.(); }} testID="empty-state-action">
               <Text style={styles.buttonText}>{actionLabel}</Text>
             </Pressable>
           ) : null}
@@ -89,42 +90,45 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontFamily: typography.fontFamilyRegular,
     lineHeight: 20,
-    letterSpacing: typography.letterSpacing
+    letterSpacing: typography.letterSpacing,
+    maxWidth: 280,
   },
   buttonContainer: {
     flexDirection: 'row',
     gap: 10
   },
   button: {
-    width: 173,
-    height: 48,
-    borderRadius: 52,
-    backgroundColor: colors.buttonBackground,
+    height: 52,
+    borderRadius: 26,
+    borderCurve: 'continuous',
+    backgroundColor: '#000000',
+    paddingHorizontal: 32,
     alignItems: 'center',
     justifyContent: 'center'
   },
   buttonText: {
-    color: colors.buttonText,
+    color: '#FFFFFF',
     fontFamily: typography.fontFamilyMedium,
-    fontSize: 17,
-    lineHeight: 24,
-    letterSpacing: -0.5,
+    fontSize: 16,
+    lineHeight: 20,
+    letterSpacing: -0.3,
     textAlign: 'center'
   },
   secondaryButton: {
-    width: 173,
-    height: 48,
-    borderRadius: 52,
+    height: 52,
+    borderRadius: 26,
+    borderCurve: 'continuous',
     backgroundColor: '#E6E6E6',
+    paddingHorizontal: 32,
     alignItems: 'center',
     justifyContent: 'center'
   },
   secondaryButtonText: {
-    color: colors.buttonBackground,
+    color: '#000000',
     fontFamily: typography.fontFamilyMedium,
-    fontSize: 17,
-    lineHeight: 24,
-    letterSpacing: -0.5,
+    fontSize: 16,
+    lineHeight: 20,
+    letterSpacing: -0.3,
     textAlign: 'center'
   }
 });

--- a/src/components/EventActionBadge.tsx
+++ b/src/components/EventActionBadge.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import { BlurView } from "expo-blur";
 
-import { spacing, typography } from "@theme/index";
+import { typography, Springs } from "@theme/index";
 
 const BADGE_HOLD_MS = 3000;
 const FADE_MS = 180;
@@ -87,9 +87,7 @@ const EventActionBadge = ({
     const enterAnim = Animated.parallel([
       Animated.spring(translateY, {
         toValue: 0,
-        damping: 20,
-        stiffness: 280,
-        mass: 0.8,
+        ...Springs.bouncyUp,
         useNativeDriver: true,
       }),
       Animated.timing(opacity, {
@@ -159,6 +157,7 @@ const styles = StyleSheet.create({
   badge: {
     position: "absolute",
     alignSelf: "center",
+    zIndex: 20,
     maxWidth: "92%",
     paddingVertical: 12,
     paddingHorizontal: 16,

--- a/src/components/EventActionConfirm.tsx
+++ b/src/components/EventActionConfirm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
+import * as Haptics from 'expo-haptics';
 
 import styles from './EventActionOverlay.styles';
 
@@ -35,7 +36,7 @@ const EventActionConfirm: React.FC<EventActionConfirmProps> = ({
     <View style={styles.promptButtons}>
       <Pressable
         accessibilityRole="button"
-        onPress={onCancel}
+        onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onCancel(); }}
         style={({ pressed }) => [
           styles.secondaryButton,
           pressed && styles.secondaryButtonPressed
@@ -45,7 +46,7 @@ const EventActionConfirm: React.FC<EventActionConfirmProps> = ({
       </Pressable>
       <Pressable
         accessibilityRole="button"
-        onPress={isConfirmLoading ? undefined : onConfirm}
+        onPress={isConfirmLoading ? undefined : () => { confirmTone === 'destructive' ? Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning) : Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); onConfirm(); }}
         disabled={isConfirmLoading}
         style={({ pressed }) => [
           styles.primaryButton,

--- a/src/components/EventActionOverlay.tsx
+++ b/src/components/EventActionOverlay.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
+import * as Haptics from "expo-haptics";
 
 import { colors } from "@theme/index";
 import BottomSheetModal from "./BottomSheetModal";
@@ -120,7 +121,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         ) : null}
         <Pressable
           accessibilityRole="button"
-          onPress={onSendInvite}
+          onPress={() => { if (!isDisabled) { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); onSendInvite(); } }}
           disabled={isDisabled}
           style={({ pressed }) => [
             styles.sendButton,
@@ -145,7 +146,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
       <View style={styles.prompt}>
         <Pressable
           accessibilityRole="button"
-          onPress={onEdit}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onEdit(); }}
           style={({ pressed }) => [
             styles.manageButton,
             pressed && styles.manageButtonPressed,
@@ -156,7 +157,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         </Pressable>
         <Pressable
           accessibilityRole="button"
-          onPress={onDelete}
+          onPress={() => { Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning); onDelete(); }}
           style={({ pressed }) => [
             styles.manageButton,
             pressed && styles.manageButtonPressed,
@@ -220,7 +221,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         </View>
         <Pressable
           accessibilityRole="button"
-          onPress={onDismiss}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onDismiss(); }}
           style={({ pressed }) => [
             styles.primaryButton,
             tone === "error" && styles.destructiveButton,
@@ -249,7 +250,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
       <View style={styles.prompt}>
         <Pressable
           accessibilityRole="button"
-          onPress={onCancelRequest}
+          onPress={() => { if (!isCancelling) { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); onCancelRequest(); } }}
           disabled={isCancelling}
           style={({ pressed }) => [
             styles.manageButton,
@@ -264,7 +265,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         </Pressable>
         <Pressable
           accessibilityRole="button"
-          onPress={onReportEvent}
+          onPress={() => { if (!isCancelling) { Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning); onReportEvent(); } }}
           disabled={isCancelling}
           style={({ pressed }) => [
             styles.manageButton,
@@ -309,7 +310,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         ) : null}
         <Pressable
           accessibilityRole="button"
-          onPress={onSubmitReport}
+          onPress={() => { if (!isDisabled) { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); onSubmitReport(); } }}
           disabled={isDisabled}
           style={({ pressed }) => [
             styles.sendButton,
@@ -338,7 +339,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
             <Pressable
               key={index}
               accessibilityRole="button"
-              onPress={item.onPress}
+              onPress={() => { if (!isDisabled) { item.destructive ? Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning) : Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); item.onPress(); } }}
               disabled={isDisabled}
               style={({ pressed }) => [
                 styles.manageButton,
@@ -374,7 +375,7 @@ const EventActionOverlay: React.FC<EventActionOverlayProps> = (props) => {
         </View>
         <Pressable
           accessibilityRole="button"
-          onPress={onDismiss}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onDismiss(); }}
           style={({ pressed }) => [
             styles.primaryButton,
             pressed && styles.primaryButtonPressed,

--- a/src/components/EventDateTimeModal.tsx
+++ b/src/components/EventDateTimeModal.tsx
@@ -1,8 +1,7 @@
 import { RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-    FlatList,
-    Platform,
     Pressable,
+    ScrollView,
     StyleSheet,
     Text,
     View,
@@ -23,7 +22,6 @@ import styles from "./EventDateTimeModal.styles";
 const WHEEL_ITEM_HEIGHT = 44;
 const WHEEL_HEIGHT = 220; // 5 visible items
 const DRAG_END_SETTLE_DELAY_MS = 16;
-const OPEN_SYNC_DELAY_MS = 32;
 
 const HOURS_12 = Array.from({ length: 12 }, (_, i) => String(i + 1)); // ["1".."12"]
 const MINUTES = Array.from({ length: 60 }, (_, i) => String(i).padStart(2, "0")); // ["00".."59"]
@@ -115,10 +113,10 @@ const EventDateTimeModal = ({
     );
     const [error, setError] = useState<string | null>(null);
 
-    const dateWheelRef = useRef<FlatList<string>>(null);
-    const hourWheelRef = useRef<FlatList<string>>(null);
-    const minuteWheelRef = useRef<FlatList<string>>(null);
-    const amPmWheelRef = useRef<FlatList<string>>(null);
+    const dateWheelRef = useRef<ScrollView>(null);
+    const hourWheelRef = useRef<ScrollView>(null);
+    const minuteWheelRef = useRef<ScrollView>(null);
+    const amPmWheelRef = useRef<ScrollView>(null);
     const wheelMomentumStateRef = useRef<Record<string, boolean>>({});
     const wheelDragSettleTimeoutRef = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
     const wheelOffsetRef = useRef<Record<string, number>>({});
@@ -146,25 +144,10 @@ const EventDateTimeModal = ({
     const selectedAmPmIndex = draftValue.getHours() >= 12 ? 1 : 0;
 
     const scrollWheelToIndex = useCallback(
-        (ref: RefObject<FlatList<string> | null>, index: number, animated = false) => {
-            ref.current?.scrollToOffset({ offset: index * WHEEL_ITEM_HEIGHT, animated });
+        (ref: RefObject<ScrollView | null>, index: number, animated = false) => {
+            ref.current?.scrollTo({ y: index * WHEEL_ITEM_HEIGHT, animated });
         },
         [],
-    );
-
-    const syncWheelPositions = useCallback(
-        (date: Date, animated = false) => {
-            const key = toDateKey(date);
-            const dateIndex = dateOptions.findIndex((opt) => opt.key === key);
-            // Hours and minutes start in the middle copy
-            const hourScrollIndex = HOUR_LOOP_OFFSET + hour24ToIndex(date.getHours());
-            const minuteScrollIndex = MINUTE_LOOP_OFFSET + date.getMinutes();
-            scrollWheelToIndex(dateWheelRef, dateIndex >= 0 ? dateIndex : 0, animated);
-            scrollWheelToIndex(hourWheelRef, hourScrollIndex, animated);
-            scrollWheelToIndex(minuteWheelRef, minuteScrollIndex, animated);
-            scrollWheelToIndex(amPmWheelRef, date.getHours() >= 12 ? 1 : 0, animated);
-        },
-        [dateOptions, scrollWheelToIndex],
     );
 
     useEffect(() => {
@@ -172,14 +155,7 @@ const EventDateTimeModal = ({
         const initialDraft = clampDateTime(toSafeDate(value), minDate, maxDate);
         setDraftValue(initialDraft);
         setError(null);
-        const syncTimeout = setTimeout(() => {
-            requestAnimationFrame(() => syncWheelPositions(initialDraft, false));
-        }, OPEN_SYNC_DELAY_MS);
-
-        return () => {
-            clearTimeout(syncTimeout);
-        };
-    }, [maxDate, minDate, syncWheelPositions, value, visible]);
+    }, [maxDate, minDate, value, visible]);
 
     const applyDateIndex = useCallback(
         (index: number) => {
@@ -232,7 +208,6 @@ const EventDateTimeModal = ({
     );
 
     // Looped scroll handlers: extract logical index and apply.
-    // Physical centering/reset to middle copy is handled in wheel settle logic.
     const handleHourScrollIndex = useCallback(
         (rawIndex: number) => {
             const logical = rawIndex % HOURS_12.length;
@@ -265,7 +240,7 @@ const EventDateTimeModal = ({
 
     const renderWheel = useCallback(
         (
-            ref: RefObject<FlatList<string> | null>,
+            ref: RefObject<ScrollView | null>,
             items: string[],
             snapOffsets: number[],
             isSelected: (index: number) => boolean,
@@ -273,7 +248,7 @@ const EventDateTimeModal = ({
             keyPrefix: string,
             // For looped columns: map any raw index to its middle-copy equivalent for press/snap
             toMiddleIndex?: (rawIndex: number) => number,
-            extraTextStyle?: object,
+            initialOffset: number = 0,
         ) => {
             const clearDragSettleTimeout = () => {
                 const timeout = wheelDragSettleTimeoutRef.current[keyPrefix];
@@ -301,47 +276,13 @@ const EventDateTimeModal = ({
                 }
             };
 
-            const renderWheelItem = ({ item, index }: { item: string; index: number }) => (
-                <Pressable
-                    key={`${keyPrefix}-${index}`}
-                    style={styles.wheelItem}
-                    onPress={() => {
-                        // Pressing always navigates to the middle-copy equivalent
-                        const target = toMiddleIndex ? toMiddleIndex(index) : index;
-                        onScrollIndex(target);
-                        scrollWheelToIndex(ref, target, true);
-                    }}
-                >
-                    <Text
-                        style={[
-                            styles.wheelText,
-                            extraTextStyle,
-                            isSelected(index) && styles.wheelTextSelected,
-                        ]}
-                    >
-                        {item}
-                    </Text>
-                </Pressable>
-            );
-
             return (
-                <FlatList
+                <ScrollView
                     ref={ref}
-                    data={items}
-                    keyExtractor={(_, index) => `${keyPrefix}-${index}`}
-                    renderItem={renderWheelItem}
-                    getItemLayout={(_, index) => ({
-                        length: WHEEL_ITEM_HEIGHT,
-                        offset: index * WHEEL_ITEM_HEIGHT,
-                        index,
-                    })}
-                    initialNumToRender={10}
-                    maxToRenderPerBatch={10}
-                    windowSize={5}
-                    removeClippedSubviews={Platform.OS === "android"}
+                    contentOffset={{ x: 0, y: initialOffset }}
                     showsVerticalScrollIndicator={false}
                     snapToOffsets={snapOffsets}
-                    decelerationRate={Platform.OS === "android" ? "normal" : "fast"}
+                    decelerationRate="fast"
                     contentContainerStyle={styles.wheelContentContainer}
                     onScroll={(e) => {
                         wheelOffsetRef.current[keyPrefix] = e.nativeEvent.contentOffset.y;
@@ -376,7 +317,28 @@ const EventDateTimeModal = ({
                             wheelOffsetRef.current[keyPrefix] ?? e.nativeEvent.contentOffset.y,
                         );
                     }}
-                />
+                >
+                    {items.map((item, index) => (
+                        <Pressable
+                            key={`${keyPrefix}-${index}`}
+                            style={styles.wheelItem}
+                            onPress={() => {
+                                const target = toMiddleIndex ? toMiddleIndex(index) : index;
+                                onScrollIndex(target);
+                                scrollWheelToIndex(ref, target, true);
+                            }}
+                        >
+                            <Text
+                                style={[
+                                    styles.wheelText,
+                                    isSelected(index) && styles.wheelTextSelected,
+                                ]}
+                            >
+                                {item}
+                            </Text>
+                        </Pressable>
+                    ))}
+                </ScrollView>
             );
         },
         [scrollWheelToIndex],
@@ -402,6 +364,8 @@ const EventDateTimeModal = ({
                             (i) => i === selectedDateIndex,
                             applyDateIndex,
                             "date",
+                            undefined,
+                            selectedDateIndex * WHEEL_ITEM_HEIGHT,
                         )}
                     </View>
 
@@ -415,6 +379,7 @@ const EventDateTimeModal = ({
                             handleHourScrollIndex,
                             "hour",
                             (i) => HOUR_LOOP_OFFSET + (i % HOURS_12.length),
+                            (HOUR_LOOP_OFFSET + selectedHourLogical) * WHEEL_ITEM_HEIGHT,
                         )}
                     </View>
 
@@ -431,6 +396,7 @@ const EventDateTimeModal = ({
                             handleMinuteScrollIndex,
                             "minute",
                             (i) => MINUTE_LOOP_OFFSET + (i % MINUTES.length),
+                            (MINUTE_LOOP_OFFSET + selectedMinuteLogical) * WHEEL_ITEM_HEIGHT,
                         )}
                     </View>
 
@@ -443,6 +409,8 @@ const EventDateTimeModal = ({
                             (i) => i === selectedAmPmIndex,
                             applyAmPmIndex,
                             "ampm",
+                            undefined,
+                            selectedAmPmIndex * WHEEL_ITEM_HEIGHT,
                         )}
                     </View>
                 </View>

--- a/src/components/ScalePressable.tsx
+++ b/src/components/ScalePressable.tsx
@@ -1,0 +1,67 @@
+import { useRef } from 'react';
+import { AccessibilityRole, Insets, Pressable, StyleProp, ViewStyle } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import { Springs } from '@theme/springs';
+
+type ScalePressableProps = {
+  onPress: () => void;
+  onPressIn?: () => void;
+  children: React.ReactNode;
+  /** Style applied to the inner Animated.View (content) */
+  style?: StyleProp<ViewStyle>;
+  /** Style applied to the outer Pressable wrapper */
+  pressableStyle?: StyleProp<ViewStyle>;
+  disabled?: boolean;
+  hitSlop?: Insets | number;
+  /** Delay in ms before scale-down starts. Use 80 for event card rows. */
+  delay?: number;
+  accessibilityRole?: AccessibilityRole;
+  testID?: string;
+};
+
+const ScalePressable = ({
+  onPress,
+  onPressIn,
+  children,
+  style,
+  pressableStyle,
+  disabled,
+  hitSlop,
+  delay = 0,
+  accessibilityRole = 'button',
+  testID,
+}: ScalePressableProps) => {
+  const scale = useSharedValue(1);
+  const animStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+  const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      hitSlop={hitSlop}
+      accessibilityRole={accessibilityRole}
+      testID={testID}
+      style={pressableStyle}
+      onPressIn={() => {
+        if (disabled) return;
+        onPressIn?.();
+        if (delay > 0) {
+          pressTimer.current = setTimeout(() => {
+            scale.value = withSpring(0.96, Springs.snappy);
+          }, delay);
+        } else {
+          scale.value = withSpring(0.96, Springs.snappy);
+        }
+      }}
+      onPressOut={() => {
+        if (pressTimer.current) { clearTimeout(pressTimer.current); pressTimer.current = null; }
+        scale.value = withSpring(1, Springs.press);
+      }}
+    >
+      <Animated.View style={[style, animStyle]}>{children}</Animated.View>
+    </Pressable>
+  );
+};
+
+export default ScalePressable;

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,37 +1,110 @@
-import { memo } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { memo, useEffect, useRef } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  interpolateColor,
+  useDerivedValue,
+  type SharedValue,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
 
-import { colors, spacing, typography } from '@theme/index';
+import { typography } from '@theme/index';
+import { Springs } from '@theme/springs';
 
 export interface SegmentedOption {
   label: string;
   value: string;
+  count?: number;
 }
 
 interface SegmentedControlProps {
   options: SegmentedOption[];
   value: string;
   onChange: (value: string) => void;
+  /** Pass the pageOffsetSV from AnimatedPager for smooth swipe-driven tab transitions. */
+  pageOffset?: SharedValue<number>;
 }
 
-const SegmentedControl = ({ options, value, onChange }: SegmentedControlProps) => {
+type TabProps = {
+  option: SegmentedOption;
+  tabIndex: number;
+  localProgress: SharedValue<number>;
+  pageOffset?: SharedValue<number>;
+  onPress: () => void;
+};
+
+const SegmentedTab = ({ option, tabIndex, localProgress, pageOffset, onPress }: TabProps) => {
+  // Derives 0→1 progress on the UI thread: 1 when selected, 0 when not
+  const effectiveProgress = useDerivedValue(() =>
+    pageOffset
+      ? Math.max(0, 1 - Math.abs(pageOffset.value - tabIndex))
+      : localProgress.value
+  );
+
+  const tabStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(effectiveProgress.value, [0, 1], ['transparent', '#000000']),
+    borderColor: interpolateColor(effectiveProgress.value, [0, 1], ['#E6E6E6', 'transparent']),
+  }));
+  const labelStyle = useAnimatedStyle(() => ({
+    color: interpolateColor(effectiveProgress.value, [0, 1], ['#494949', '#FFFFFF']),
+  }));
+  const countStyle = useAnimatedStyle(() => ({
+    color: interpolateColor(effectiveProgress.value, [0, 1], ['#808080', 'rgba(255,255,255,0.7)']),
+  }));
+
+  return (
+    <Pressable onPress={onPress} accessibilityRole="tab">
+      <Animated.View style={[styles.tab, tabStyle]}>
+        <Animated.Text style={[styles.label, labelStyle]}>
+          {option.label}
+        </Animated.Text>
+        {option.count != null && option.count > 0 && (
+          <Animated.Text style={[styles.count, countStyle]}>
+            {option.count}
+          </Animated.Text>
+        )}
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+// Up to 4 tabs — shared values must be created unconditionally at top level.
+const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedControlProps) => {
+  const selectedIndex = options.findIndex(o => o.value === value);
+  const prevIndex = useRef(selectedIndex);
+
+  const sv0 = useSharedValue(selectedIndex === 0 ? 1 : 0);
+  const sv1 = useSharedValue(selectedIndex === 1 ? 1 : 0);
+  const sv2 = useSharedValue(selectedIndex === 2 ? 1 : 0);
+  const sv3 = useSharedValue(selectedIndex === 3 ? 1 : 0);
+  const allSvs = [sv0, sv1, sv2, sv3];
+
+  // Spring-based fallback for programmatic tab changes (tap) when pageOffset not provided
+  useEffect(() => {
+    const prev = prevIndex.current;
+    if (prev === selectedIndex) return;
+    allSvs[prev].value = 0;
+    allSvs[selectedIndex].value = withSpring(1, Springs.snappy);
+    prevIndex.current = selectedIndex;
+  }, [selectedIndex]);
+
   return (
     <View style={styles.container}>
-      {options.map((option) => {
-        const isActive = option.value === value;
-        return (
-          <Pressable
-            key={option.value}
-            onPress={() => onChange(option.value)}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: isActive }}
-            style={[styles.tab, isActive && styles.tabActive]}
-            testID={`segment-${option.value}`}
-          >
-            <Text style={[styles.label, isActive && styles.labelActive]}>{option.label}</Text>
-          </Pressable>
-        );
-      })}
+      {options.map((option, i) => (
+        <SegmentedTab
+          key={option.value}
+          option={option}
+          tabIndex={i}
+          localProgress={allSvs[i]}
+          pageOffset={pageOffset}
+          onPress={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            onChange(option.value);
+          }}
+        />
+      ))}
     </View>
   );
 };
@@ -42,27 +115,26 @@ const styles = StyleSheet.create({
     gap: 5,
   },
   tab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     paddingVertical: 8,
     paddingHorizontal: 10,
     borderRadius: 10,
+    borderCurve: 'continuous',
     borderWidth: 1,
-    borderColor: '#E6E6E6',
-    backgroundColor: 'transparent',
-  },
-  tabActive: {
-    borderColor: 'transparent',
-    backgroundColor: '#E6E6E6',
   },
   label: {
     fontSize: 15,
-    color: '#494949',
     fontFamily: typography.fontFamilyMedium,
     lineHeight: 20,
     letterSpacing: -0.3,
   },
-  labelActive: {
-    color: colors.text,
+  count: {
+    fontSize: 15,
     fontFamily: typography.fontFamilyMedium,
+    lineHeight: 20,
+    letterSpacing: -0.3,
   },
 });
 

--- a/src/components/SelectionModal.tsx
+++ b/src/components/SelectionModal.tsx
@@ -54,7 +54,7 @@ function SelectionModal<T>({
             </View>
             <Pressable
                 style={styles.selectButton}
-                onPress={onConfirm}
+                onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onConfirm(); }}
                 testID="selection-modal-confirm"
                 accessibilityRole="button"
             >

--- a/src/components/SignInButtons.tsx
+++ b/src/components/SignInButtons.tsx
@@ -13,6 +13,8 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
 import * as AppleAuthentication from "expo-apple-authentication";
 
+import * as Haptics from "expo-haptics";
+
 import { useAuth } from "@context/AuthContext";
 import { RootStackParamList } from "@navigation/types";
 import { colors, spacing, typography } from "@theme/index";
@@ -106,6 +108,7 @@ const SignInButtons = ({ onSignInSuccess }: SignInButtonsProps = {}) => {
     );
 
     const onGooglePress = useCallback(async () => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         if (!isNativeAvailable) {
             Alert.alert(
                 "Google Sign-In Unavailable",
@@ -138,6 +141,7 @@ const SignInButtons = ({ onSignInSuccess }: SignInButtonsProps = {}) => {
     }, [handlePostSignInNavigation, isNativeAvailable, signInWithGoogle]);
 
     const onApplePress = useCallback(async () => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         if (Platform.OS !== "ios") {
             Alert.alert(
                 "Apple Sign-In (Dev Preview)",

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -48,11 +48,7 @@ const UserAvatar = ({
     <View
       style={[
         styles.frame,
-        {
-          width: size,
-          height: size,
-          borderRadius: size / 2,
-        },
+        { width: size, height: size, borderRadius: size / 2 },
         style,
         !avatarUri && { backgroundColor },
       ]}
@@ -68,14 +64,7 @@ const UserAvatar = ({
       ) : (
         <View style={styles.initialsFrame}>
           <Text
-            style={[
-              styles.initials,
-              {
-                fontSize,
-                lineHeight,
-              },
-              textStyle,
-            ]}
+            style={[styles.initials, { fontSize, lineHeight }, textStyle]}
             numberOfLines={1}
           >
             {initials}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,17 +1,25 @@
 import { NavigationContainer, DefaultTheme } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createStackNavigator, CardStyleInterpolators } from "@react-navigation/stack";
+import type { StackCardInterpolationProps } from "@react-navigation/stack";
 import {
   Animated,
+  Pressable,
   TouchableOpacity,
   View,
   StyleSheet,
+  useWindowDimensions,
 } from "react-native";
+import ReAnimated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from "react-native-reanimated";
 import * as Haptics from "expo-haptics";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import Svg, { Circle, Path } from "react-native-svg";
 import { BlurView } from "expo-blur";
-
+import { enableScreens } from "react-native-screens";
 import HomeScreen from "@screens/HomeScreen";
 import CreateEventScreen from "@screens/CreateEventScreen";
 import MyEventsScreen from "@screens/MyEventsScreen";
@@ -25,8 +33,8 @@ import OnboardingScreen from "@screens/OnboardingScreen";
 import { navigationRef } from "@navigation/navigationRef";
 import { RootStackParamList, RootTabParamList } from "@navigation/types";
 import { colors } from "@theme/colors";
+import { Springs } from "@theme/springs";
 import { useChat } from "@context/ChatContext";
-import GoogleSignIn from "@screens/GoogleSignIn";
 import JoinRequestsScreen from "@screens/JoinRequestsScreen";
 import PendingRequestsScreen from "@screens/PendingRequestsScreen";
 import EditProfileScreen from "@screens/EditProfileScreen";
@@ -36,9 +44,173 @@ import HelpScreen from "@screens/HelpScreen";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { BottomTabBarButtonProps } from "@react-navigation/bottom-tabs";
 
-const Tab = createBottomTabNavigator<RootTabParamList>();
-const Stack = createNativeStackNavigator<RootStackParamList>();
+// Render tab screens as plain JS Views so React Navigation's tabAnims-driven
+// opacity (animation: "fade") applies correctly without native screen management
+// interfering by removing screens from the hierarchy before the fade finishes.
+enableScreens(false);
 
+const Tab = createBottomTabNavigator<RootTabParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
+
+
+// ─── Stack screen animation ───────────────────────────────────────────────────
+// Push (open):  incoming slides from 30% right — matches tab animation
+// Pop  (close): card slides fully off to the right — standard iOS back feel
+const tabLikeInterpolator = ({ current, next, layouts, closing }: StackCardInterpolationProps) => {
+  const { width } = layouts.screen;
+
+  if (next) {
+    // This card is below an incoming card: slide left + fade out
+    return {
+      cardStyle: {
+        transform: [{
+          translateX: next.progress.interpolate({ inputRange: [0, 1], outputRange: [0, -width * 0.2], extrapolate: 'clamp' }),
+        }],
+        opacity: next.progress.interpolate({ inputRange: [0, 1], outputRange: [1, 0], extrapolate: 'clamp' }),
+      },
+    };
+  }
+
+  // Top card: open from 30% right, close to full width right
+  const translateXOpen  = current.progress.interpolate({ inputRange: [0, 1], outputRange: [width * 0.3, 0], extrapolate: 'clamp' });
+  const translateXClose = current.progress.interpolate({ inputRange: [0, 1], outputRange: [width, 0],       extrapolate: 'clamp' });
+
+  // Blend: when closing=0 use open translation, when closing=1 use close translation
+  const translateX = Animated.add(
+    translateXOpen,
+    Animated.multiply(closing, Animated.subtract(translateXClose, translateXOpen)),
+  );
+
+  return {
+    cardStyle: {
+      transform: [{ translateX }],
+    },
+  };
+};
+
+const tabLikeTransitionSpec = {
+  open:  { animation: 'spring' as const, config: Springs.snappy },
+  close: { animation: 'spring' as const, config: Springs.snappy },
+};
+
+// Full-screen slide-up modal — no background scaling/dimming
+const slideFromBottomInterpolator = ({ current, layouts }: StackCardInterpolationProps) => ({
+  cardStyle: {
+    transform: [{
+      translateY: current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [layouts.screen.height, 0],
+        extrapolate: 'clamp',
+      }),
+    }],
+  },
+});
+
+const slideFromBottomTransitionSpec = {
+  open:  { animation: 'spring' as const, config: Springs.snappy },
+  close: { animation: 'spring' as const, config: Springs.snappy },
+};
+
+// Sheet modal: backdrop fades in place (overlayStyle, requires cardOverlayEnabled),
+// transparent card slides up carrying the sheet content anchored to bottom.
+// Matches BottomSheetModal behaviour exactly.
+const sheetModalInterpolator = ({ current, layouts }: StackCardInterpolationProps) => ({
+  overlayStyle: {
+    opacity: current.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 0.4],
+      extrapolate: 'clamp',
+    }),
+  },
+  cardStyle: {
+    transform: [{
+      translateY: current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [layouts.screen.height, 0],
+        extrapolate: 'clamp',
+      }),
+    }],
+  },
+});
+
+const sheetModalTransitionSpec = {
+  open:  { animation: 'spring' as const, config: Springs.bouncyUp },
+  close: { animation: 'spring' as const, config: Springs.snappy },
+};
+
+// How far the sheet background extends below the screen.
+// When the spring overshoots (translateY goes negative), the card's bottom
+// edge rises above the actual screen bottom, exposing a gap. Extending the
+// sheet background by this amount fills that gap with white instead of
+// revealing the underlying screen.
+const SHEET_BOUNCE_BUFFER = 80;
+
+// Sheet modal wrapper.
+// Backdrop and sheet are NON-OVERLAPPING siblings:
+//   • Backdrop Pressable covers only the top 20% → tapping above sheet closes it
+//   • Sheet View covers bottom 80% with explicit height → no touch interception
+//     needed, so the inner ScrollView receives all gestures unimpeded.
+// onStartShouldSetResponder is intentionally absent from the sheet — it would
+// intercept touches at the JS bridge before the native UIScrollView can scroll.
+const SheetWrapper = ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => {
+  const { height: screenHeight } = useWindowDimensions();
+  const sheetHeight = screenHeight * 0.8;
+  return (
+    <View style={{ flex: 1 }} pointerEvents="box-none">
+      <Pressable
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: screenHeight - sheetHeight,
+        }}
+        onPress={onClose}
+      />
+      {/* Outer container extends SHEET_BOUNCE_BUFFER px below the screen so
+          the bounce overshoot never exposes the underlying content. */}
+      <View
+        style={{
+          position: 'absolute',
+          bottom: -SHEET_BOUNCE_BUFFER,
+          left: 0,
+          right: 0,
+          height: sheetHeight + SHEET_BOUNCE_BUFFER,
+          backgroundColor: colors.background,
+          borderTopLeftRadius: 28,
+          borderTopRightRadius: 28,
+          overflow: 'hidden',
+        }}
+      >
+        <View style={{ height: sheetHeight }}>
+          {children}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const EventDetailsOverlaySheet = (props: any) => (
+  <SheetWrapper onClose={() => props.navigation.goBack()}>
+    <EventDetailsScreen {...props} />
+  </SheetWrapper>
+);
+
+const PendingRequestsSheet = (props: any) => (
+  <SheetWrapper onClose={() => props.navigation.goBack()}>
+    <PendingRequestsScreen {...props} />
+  </SheetWrapper>
+);
+
+
+
+// ─── Tab screen wrappers ─────────────────────────────────────────────────────
+const EventsTab = (props: any) => <HomeScreen {...props} />;
+const MyEventsTab = (props: any) => <MyEventsScreen {...props} />;
+const MessagesTab = (props: any) => <MessagesScreen {...props} />;
+const ProfileTab = (props: any) => <ProfileScreen {...props} />;
+
+// ─── Tab bar background ──────────────────────────────────────────────────────
 const TabBarBackground = () => (
   <View style={tabBarStyles.backgroundContainer}>
     <BlurView
@@ -46,9 +218,7 @@ const TabBarBackground = () => (
       tint="light"
       style={StyleSheet.absoluteFill}
     />
-    {/* Fill: #FBFBFB at 60% opacity */}
     <View style={tabBarStyles.frostedOverlay} />
-    {/* Stroke on top: 1px solid white */}
     <View style={tabBarStyles.topBorder} />
   </View>
 );
@@ -72,6 +242,7 @@ const tabBarStyles = StyleSheet.create({
   },
 });
 
+// ─── Tab icons ───────────────────────────────────────────────────────────────
 type TabIconProps = {
   focused: boolean;
   color: string;
@@ -82,49 +253,6 @@ const TAB_ICON_HEIGHT = 29;
 
 const getFillColor = (focused: boolean) =>
   focused ? colors.activeTabIndicator : "none";
-
-const VibratingTabBarButton = (props: BottomTabBarButtonProps) => {
-  const { onPress, style, children, accessibilityLabel, testID } = props;
-  const scaleAnim = useRef(new Animated.Value(1)).current;
-
-  const triggerScale = () => {
-    scaleAnim.setValue(1);
-    Animated.sequence([
-      Animated.timing(scaleAnim, {
-        toValue: 0.8,
-        duration: 67,
-        useNativeDriver: true,
-      }),
-      Animated.timing(scaleAnim, {
-        toValue: 1,
-        duration: 67,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  };
-
-  const handlePress = (e: Parameters<NonNullable<typeof onPress>>[0]) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    triggerScale();
-    if (onPress) {
-      onPress(e);
-    }
-  };
-
-  return (
-    <TouchableOpacity
-      style={style}
-      onPress={handlePress}
-      activeOpacity={1}
-      accessibilityLabel={accessibilityLabel}
-      testID={testID}
-    >
-      <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
-        {children}
-      </Animated.View>
-    </TouchableOpacity>
-  );
-};
 
 const EventsTabIcon = ({ focused, color }: TabIconProps) => {
   const strokeColor = color;
@@ -246,8 +374,8 @@ const MessagesTabIcon = ({ focused, color }: TabIconProps) => {
         <View
           style={{
             position: "absolute",
-            top: 5,
-            right: 15,
+            top: 0,
+            right: 2,
             width: 10,
             height: 10,
             borderRadius: 5,
@@ -302,8 +430,45 @@ const ProfileTabIcon = ({ focused, color }: TabIconProps) => {
   );
 };
 
+// ─── Vibrating tab bar button ────────────────────────────────────────────────
+type VibratingTabBarButtonProps = BottomTabBarButtonProps & { pageIndex: number };
+
+const VibratingTabBarButton = ({
+  onPress,
+  style,
+  children,
+  accessibilityLabel,
+  testID,
+}: VibratingTabBarButtonProps) => {
+  const scale = useSharedValue(1);
+  const animStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+
+  const handlePress = (e: Parameters<NonNullable<typeof onPress>>[0]) => {
+    scale.value = 0.8;
+    scale.value = withSpring(1, Springs.elegant);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    if (onPress) onPress(e);
+  };
+
+  return (
+    <TouchableOpacity
+      style={style}
+      onPress={handlePress}
+      activeOpacity={1}
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+    >
+      <ReAnimated.View style={animStyle}>
+        {children}
+      </ReAnimated.View>
+    </TouchableOpacity>
+  );
+};
+
+// ─── Main tabs ───────────────────────────────────────────────────────────────
 const MainTabs = () => {
   const insets = useSafeAreaInsets();
+
   const tabBarBaseStyle = useMemo(
     () => ({
       backgroundColor: "transparent",
@@ -311,85 +476,108 @@ const MainTabs = () => {
       paddingBottom: insets.bottom,
       paddingTop: 8,
       position: "absolute" as const,
-      // borderTopWidth: 3.18,
-      // borderTopColor: "#FFFFFF",
       elevation: 0,
     }),
     [insets.bottom],
   );
+
+  const tabButtons = useMemo(
+    () => ({
+      events: (props: BottomTabBarButtonProps) => (
+        <VibratingTabBarButton {...props} pageIndex={0} />
+      ),
+      myEvents: (props: BottomTabBarButtonProps) => (
+        <VibratingTabBarButton {...props} pageIndex={1} />
+      ),
+      create: (props: BottomTabBarButtonProps) => (
+        <VibratingTabBarButton {...props} pageIndex={2} />
+      ),
+      messages: (props: BottomTabBarButtonProps) => (
+        <VibratingTabBarButton {...props} pageIndex={3} />
+      ),
+      profile: (props: BottomTabBarButtonProps) => (
+        <VibratingTabBarButton {...props} pageIndex={4} />
+      ),
+    }),
+    [],
+  );
+
   return (
     <Tab.Navigator
-      screenOptions={() => {
-        return {
+        screenOptions={() => ({
           headerShown: false,
           tabBarShowLabel: false,
           tabBarStyle: tabBarBaseStyle,
           tabBarBackground: () => <TabBarBackground />,
           tabBarActiveTintColor: colors.activeTabIndicator,
           tabBarInactiveTintColor: colors.tabInactive,
-          tabBarButton: (props) => <VibratingTabBarButton {...props} />,
           lazy: false,
           animation: "none",
           detachInactiveScreens: false,
-          sceneStyle: { backgroundColor: colors.background },
-        };
-      }}
-    >
-      <Tab.Screen
-        name="Events"
-        component={HomeScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <EventsTabIcon focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="MyEvents"
-        component={MyEventsScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <MyEventsTabIcon focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="Create"
-        component={View}
-        listeners={({ navigation }) => ({
-          tabPress: (e) => {
-            e.preventDefault();
-            (navigation as any).navigate("CreateEvent", { editEventId: null });
-          },
+          sceneStyle: { backgroundColor: "transparent" },
         })}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <CreateTabIcon focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="Messages"
-        component={MessagesScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <MessagesTabIcon focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="Profile"
-        component={ProfileScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <ProfileTabIcon focused={focused} color={color} />
-          ),
-        }}
-      />
-    </Tab.Navigator>
+      >
+        <Tab.Screen
+          name="Events"
+          component={EventsTab}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <EventsTabIcon focused={focused} color={color} />
+            ),
+            tabBarButton: tabButtons.events,
+          }}
+        />
+        <Tab.Screen
+          name="MyEvents"
+          component={MyEventsTab}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <MyEventsTabIcon focused={focused} color={color} />
+            ),
+            tabBarButton: tabButtons.myEvents,
+          }}
+        />
+        <Tab.Screen
+          name="Create"
+          component={View}
+          listeners={({ navigation }) => ({
+            tabPress: (e) => {
+              e.preventDefault();
+              (navigation as any).navigate("CreateEvent", { editEventId: null });
+            },
+          })}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <CreateTabIcon focused={focused} color={color} />
+            ),
+            tabBarButton: tabButtons.create,
+          }}
+        />
+        <Tab.Screen
+          name="Messages"
+          component={MessagesTab}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <MessagesTabIcon focused={focused} color={color} />
+            ),
+            tabBarButton: tabButtons.messages,
+          }}
+        />
+        <Tab.Screen
+          name="Profile"
+          component={ProfileTab}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <ProfileTabIcon focused={focused} color={color} />
+            ),
+            tabBarButton: tabButtons.profile,
+          }}
+        />
+      </Tab.Navigator>
   );
 };
 
+// ─── Root navigator ──────────────────────────────────────────────────────────
 const AppNavigator = () => {
   const navigationTheme = {
     ...DefaultTheme,
@@ -410,34 +598,28 @@ const AppNavigator = () => {
         screenOptions={{
           headerShown: false,
           gestureEnabled: true,
-          contentStyle: { backgroundColor: colors.background },
-          animation: "fade_from_bottom",
-          animationDuration: 200,
+          cardStyle: { backgroundColor: colors.background },
+          cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter,
+          transitionSpec: {
+            open:  { animation: 'spring' as const, config: Springs.snappy },
+            close: { animation: 'spring' as const, config: Springs.snappy },
+          },
         }}
       >
         <Stack.Screen
           name="Splash"
           component={SplashScreen}
           options={{
-            animation: "none",
-            headerShown: false,
-            contentStyle: { backgroundColor: "#050F29" },
+            cardStyleInterpolator: CardStyleInterpolators.forNoAnimation,
+            cardStyle: { backgroundColor: "#050F29" },
           }}
         />
         <Stack.Screen
           name="Main"
           component={MainTabs}
           options={{
-            animation: "fade",
-          }}
-        />
-        <Stack.Screen
-          name="Login"
-          component={GoogleSignIn}
-          options={{
-            presentation: "transparentModal",
-            animation: "fade",
-            animationDuration: 150,
+            gestureEnabled: false,
+            cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter,
           }}
         />
         <Stack.Screen
@@ -445,95 +627,101 @@ const AppNavigator = () => {
           component={OnboardingScreen}
           options={{
             gestureEnabled: false,
-            animation: "fade",
+            cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter,
           }}
         />
         <Stack.Screen
           name="EventDetails"
           component={EventDetailsScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
         <Stack.Screen
           name="JoinRequests"
           component={JoinRequestsScreen}
           options={{
-            presentation: "modal",
-            animation: "slide_from_bottom",
-            animationDuration: 350,
+            cardStyleInterpolator: slideFromBottomInterpolator,
+            transitionSpec: slideFromBottomTransitionSpec,
           }}
         />
         <Stack.Screen
           name="PendingRequests"
-          component={PendingRequestsScreen}
+          component={PendingRequestsSheet}
           options={{
-            presentation: "modal",
-            animation: "slide_from_bottom",
-            animationDuration: 350,
+            presentation: "transparentModal",
+            gestureEnabled: false,
+            cardOverlayEnabled: true,
+            cardStyle: { backgroundColor: "transparent" },
+            cardStyleInterpolator: sheetModalInterpolator,
+            transitionSpec: sheetModalTransitionSpec,
           }}
         />
         <Stack.Screen
           name="EventDetailsOverlay"
-          component={EventDetailsScreen}
+          component={EventDetailsOverlaySheet}
           options={{
-            presentation: "modal",
-            animation: "slide_from_bottom",
-            animationDuration: 350,
+            presentation: "transparentModal",
+            gestureEnabled: false,
+            cardOverlayEnabled: true,
+            cardStyle: { backgroundColor: "transparent" },
+            cardStyleInterpolator: sheetModalInterpolator,
+            transitionSpec: sheetModalTransitionSpec,
           }}
         />
         <Stack.Screen
           name="CreateEvent"
           component={CreateEventScreen}
           options={{
-            animation: "slide_from_bottom",
-            animationDuration: 250,
+            cardStyleInterpolator: slideFromBottomInterpolator,
+            transitionSpec: slideFromBottomTransitionSpec,
           }}
         />
         <Stack.Screen
           name="EditProfile"
           component={EditProfileScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
         <Stack.Screen
           name="PastEvents"
           component={PastEventsScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
         <Stack.Screen
           name="PrivacyPolicy"
           component={PrivacyPolicyScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
         <Stack.Screen
           name="Help"
           component={HelpScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
         <Stack.Screen
           name="ChatThread"
           component={ChatThreadScreen}
           options={{
-            animation: "slide_from_right",
-            animationDuration: 350,
+            cardStyleInterpolator: tabLikeInterpolator,
+            transitionSpec: tabLikeTransitionSpec,
           }}
         />
       </Stack.Navigator>
     </NavigationContainer>
   );
 };
+
 
 export default AppNavigator;

--- a/src/navigation/navigationRef.ts
+++ b/src/navigation/navigationRef.ts
@@ -12,6 +12,6 @@ export const resetToLogin = () => {
 
   navigationRef.reset({
     index: 0,
-    routes: [{ name: "Login" }],
+    routes: [{ name: "Main" }],
   });
 };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,13 +1,5 @@
 export type RootStackParamList = {
   Splash: undefined;
-  Login:
-    | {
-        redirect?: {
-          screen: keyof RootTabParamList;
-          params?: RootTabParamList[keyof RootTabParamList];
-        };
-      }
-    | undefined;
   Main: any;
   Onboarding: undefined;
   EventDetails: {

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -1,5 +1,6 @@
 import { Feather } from "@expo/vector-icons";
 import SendIcon from "@assets/chat-icons/send.svg";
+import * as Haptics from "expo-haptics";
 import {
   Dimensions,
   FlatList,
@@ -142,8 +143,14 @@ const ChatThreadScreen = () => {
     );
   }, [activeConversation]);
 
+  const isManuallyLeavingRef = useRef(false);
+
   useEffect(() => {
     if (!activeConversationId) {
+      if (isManuallyLeavingRef.current) {
+        isManuallyLeavingRef.current = false;
+        return;
+      }
       if (navigation.canGoBack()) {
         navigation.goBack();
       } else {
@@ -220,6 +227,8 @@ const ChatThreadScreen = () => {
   }, [messages.length]);
 
   const handleBack = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    isManuallyLeavingRef.current = true;
     setActiveConversation(null);
     if (navigation.canGoBack()) {
       navigation.goBack();
@@ -232,6 +241,7 @@ const ChatThreadScreen = () => {
     if (!activeConversationId || !draft.trim()) {
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     sendMessage(activeConversationId, draft.trim());
     setDraft("");
   };
@@ -263,6 +273,7 @@ const ChatThreadScreen = () => {
     ) {
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     navigation.navigate("PendingRequests", {
       conversationId: activeConversation.id,
       eventId: activeConversation.eventId,
@@ -343,7 +354,7 @@ const ChatThreadScreen = () => {
     );
 
     const bubbleContent = item.failed ? (
-      <Pressable onPress={() => retryMessage(item.conversationId, item)}>
+      <Pressable onPress={() => { Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning); retryMessage(item.conversationId, item); }}>
         {bubble}
       </Pressable>
     ) : (
@@ -387,6 +398,7 @@ const ChatThreadScreen = () => {
         coverUri={eventCoverUri}
         onTitlePress={() => {
           if (activeConversation?.eventId) {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
             navigation.navigate("EventDetailsOverlay", {
               eventId: String(activeConversation.eventId),
               readOnly: true,

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -306,10 +306,11 @@ const CreateEventScreen = () => {
             const form = formOverride ?? getCurrentFormState();
             const trimmedName = form.eventName.trim();
             const trimmedDescription = form.description.trim();
+            const trimmedLocation = form.location.trim();
 
-            if (!trimmedName && !trimmedDescription) {
+            if (!trimmedName || !trimmedDescription || !trimmedLocation) {
                 Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-                setSubmitError("Please fill in all fields");
+                setSubmitError("All fields are required");
                 return;
             }
 
@@ -345,7 +346,7 @@ const CreateEventScreen = () => {
             setSubmitError(null);
             setIsSubmitting(true);
 
-            const locationLabel = form.location.trim() || "To be decided";
+            const locationLabel = trimmedLocation;
             const [rangeStart, rangeEnd] = form.ageRange;
             const minAge = Math.min(rangeStart, rangeEnd);
             const maxAge = Math.max(rangeStart, rangeEnd);
@@ -507,12 +508,8 @@ const CreateEventScreen = () => {
         }
 
         // Authenticated user flow — validate and submit
-        const hasContent =
-            formState.eventName.trim().length > 0 ||
-            formState.description.trim().length > 0;
-
-        if (!hasContent) {
-            setSubmitError("Please fill in all fields");
+        if (!formState.eventName.trim() || !formState.description.trim() || !formState.location.trim()) {
+            setSubmitError("All fields are required");
             return;
         }
 

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -9,10 +9,12 @@ import {
   View,
 } from "react-native";
 import { useCallback, useState } from "react";
+import ScalePressable from "@components/ScalePressable";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import ScreenContainer from "@components/ScreenContainer";
 import UserAvatar from "@components/UserAvatar";
@@ -33,6 +35,7 @@ type EditProfileNavigation = NativeStackNavigationProp<RootStackParamList>;
 const EditProfileScreen = () => {
   const navigation = useNavigation<EditProfileNavigation>();
   const { user, updateProfile } = useAuth();
+  const insets = useSafeAreaInsets();
 
   const [editName, setEditName] = useState(user?.name ?? "");
   const [editAvatarBase64, setEditAvatarBase64] = useState<string | null>(null);
@@ -129,6 +132,7 @@ const EditProfileScreen = () => {
 
   return (
     <ScreenContainer>
+<<<<<<< Updated upstream
       {/* Header */}
       <View style={styles.header}>
         <Pressable
@@ -169,43 +173,97 @@ const EditProfileScreen = () => {
               <Feather name="x" size={13} color="#FFFFFF" />
             </TouchableOpacity>
           )}
+=======
+      <View style={styles.inner}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
+            style={styles.backButton}
+            hitSlop={8}
+          >
+            <Feather name="chevron-left" size={20} color={colors.text} />
+          </Pressable>
+          <Text style={styles.headerTitle}>Edit Profile</Text>
+>>>>>>> Stashed changes
         </View>
 
-        <TextInput
-          style={styles.nameInput}
-          value={editName}
-          onChangeText={setEditName}
-          placeholder="Your Name"
-          placeholderTextColor="#9CA3AF"
-          autoCapitalize="words"
-          autoCorrect={false}
-          textAlign="center"
-          returnKeyType="done"
-          maxLength={50}
-        />
-      </View>
+        {/* Avatar + Name */}
+        <View style={styles.avatarSection}>
+          <View style={styles.avatarWrapper}>
+            <TouchableOpacity onPress={pickImage} accessibilityRole="button">
+              {editAvatarUri ? (
+                <Image source={{ uri: editAvatarUri }} style={styles.avatarImage} />
+              ) : (
+                <LinearGradient
+                  colors={["#818CF8", "#6366F1", "#8B5CF6"]}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 1 }}
+                  style={styles.avatarGradient}
+                >
+                  <Text style={styles.avatarInitial}>
+                    {user?.name?.charAt(0).toUpperCase() ?? "?"}
+                  </Text>
+                </LinearGradient>
+              )}
+              <View style={styles.cameraBadge}>
+                <CameraIcon width={20} height={20} />
+              </View>
+            </TouchableOpacity>
+            {editAvatarUri && (
+              <TouchableOpacity
+                style={styles.removeBadge}
+                onPress={handleRemoveAvatar}
+                accessibilityRole="button"
+                accessibilityLabel="Remove photo"
+              >
+                <Feather name="x" size={16} color="#FFFFFF" />
+              </TouchableOpacity>
+            )}
+          </View>
 
-      {/* Save Button */}
-      <Pressable
-        style={[
-          styles.saveButton,
-          (!editHasChanges || isSubmitting) && styles.saveButtonDisabled,
-        ]}
-        onPress={handleSave}
-        disabled={!editHasChanges || isSubmitting}
-        accessibilityRole="button"
-      >
-        {isSubmitting ? (
-          <ActivityIndicator size="small" color="#FFFFFF" />
-        ) : (
-          <Text style={styles.saveButtonText}>Save</Text>
-        )}
-      </Pressable>
+          <TextInput
+            style={styles.nameInput}
+            value={editName}
+            onChangeText={setEditName}
+            placeholder="Your Name"
+            placeholderTextColor="#9CA3AF"
+            autoCapitalize="words"
+            autoCorrect={false}
+            textAlign="center"
+            returnKeyType="done"
+            maxLength={50}
+          />
+        </View>
+
+        {/* Save Button — pinned to bottom */}
+        <View style={styles.buttonSection}>
+          <ScalePressable
+            onPress={handleSave}
+            disabled={!editHasChanges || isSubmitting}
+            style={[styles.saveButton, (!editHasChanges || isSubmitting) && styles.saveButtonDisabled]}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator size="small" color="#9CA3AF" />
+            ) : (
+              <Text style={[styles.saveButtonText, (!editHasChanges || isSubmitting) && styles.saveButtonTextDisabled]}>
+                Save
+              </Text>
+            )}
+          </ScalePressable>
+        </View>
+      </View>
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
+  inner: {
+    flex: 1,
+    justifyContent: "space-between",
+  },
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -225,28 +283,48 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   avatarSection: {
+    flex: 1,
     alignItems: "center",
-    paddingTop: spacing.xl,
-    marginBottom: spacing.md,
+    justifyContent: "center",
+    marginBottom: 100,
   },
   avatarWrapper: {
     position: "relative",
-    marginBottom: 16,
+    marginBottom: 24,
   },
+<<<<<<< Updated upstream
   avatarFrame: {
     width: 80,
     height: 80,
     borderRadius: 80,
     borderWidth: 2,
     borderColor: "#E6E6E6",
+=======
+  avatarGradient: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarImage: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+  },
+  avatarInitial: {
+    fontSize: 40,
+    color: "#FFFFFF",
+    fontFamily: typography.fontFamilyBold,
+>>>>>>> Stashed changes
   },
   cameraBadge: {
     position: "absolute",
-    bottom: -2,
-    right: -4,
-    width: 28,
-    height: 28,
-    borderRadius: 14,
+    bottom: 4,
+    right: -2,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     backgroundColor: "white",
     justifyContent: "center",
     alignItems: "center",
@@ -258,11 +336,11 @@ const styles = StyleSheet.create({
   },
   removeBadge: {
     position: "absolute",
-    top: -2,
-    right: -2,
-    width: 22,
-    height: 22,
-    borderRadius: 11,
+    top: 0,
+    right: 2,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
     backgroundColor: "#000000",
     justifyContent: "center",
     alignItems: "center",
@@ -277,12 +355,15 @@ const styles = StyleSheet.create({
     fontSize: 24,
     color: "#000000",
     textAlign: "center",
-    paddingVertical: 8,
+    paddingVertical: 12,
     minWidth: 200,
     letterSpacing: -0.5,
   },
+  buttonSection: {
+    paddingHorizontal: 16,
+  },
   saveButton: {
-    backgroundColor: colors.primary,
+    backgroundColor: "#000000",
     borderRadius: 999,
     borderCurve: "continuous",
     height: 52,
@@ -290,15 +371,16 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   saveButtonDisabled: {
-    opacity: 0.5,
+    backgroundColor: "#E5E5E5",
   },
   saveButtonText: {
-    color: colors.buttonText,
-    fontSize: 18,
+    color: "#FFFFFF",
+    fontSize: 17,
     fontFamily: typography.fontFamilyMedium,
-    lineHeight: 24,
-    letterSpacing: -0.5,
     textAlign: "center",
+  },
+  saveButtonTextDisabled: {
+    color: "#9CA3AF",
   },
 });
 

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -132,48 +132,6 @@ const EditProfileScreen = () => {
 
   return (
     <ScreenContainer>
-<<<<<<< Updated upstream
-      {/* Header */}
-      <View style={styles.header}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-          onPress={() => navigation.goBack()}
-          style={styles.backButton}
-          hitSlop={8}
-        >
-          <Feather name="chevron-left" size={20} color={colors.text} />
-        </Pressable>
-        <Text style={styles.headerTitle}>Edit Profile</Text>
-        <View style={styles.backButton} />
-      </View>
-
-      {/* Avatar */}
-      <View style={styles.avatarSection}>
-        <View style={styles.avatarWrapper}>
-          <TouchableOpacity onPress={pickImage} accessibilityRole="button">
-            <UserAvatar
-              avatar={editAvatarValue}
-              name={editName.trim() || user?.name}
-              seed={user?.id ?? editName}
-              size={80}
-              style={styles.avatarFrame}
-            />
-            <View style={styles.cameraBadge}>
-              <CameraIcon width={14} height={14} />
-            </View>
-          </TouchableOpacity>
-          {editAvatarValue && (
-            <TouchableOpacity
-              style={styles.removeBadge}
-              onPress={handleRemoveAvatar}
-              accessibilityRole="button"
-              accessibilityLabel="Remove photo"
-            >
-              <Feather name="x" size={13} color="#FFFFFF" />
-            </TouchableOpacity>
-          )}
-=======
       <View style={styles.inner}>
         {/* Header */}
         <View style={styles.header}>
@@ -187,39 +145,32 @@ const EditProfileScreen = () => {
             <Feather name="chevron-left" size={20} color={colors.text} />
           </Pressable>
           <Text style={styles.headerTitle}>Edit Profile</Text>
->>>>>>> Stashed changes
+          <View style={styles.backButton} />
         </View>
 
         {/* Avatar + Name */}
         <View style={styles.avatarSection}>
           <View style={styles.avatarWrapper}>
             <TouchableOpacity onPress={pickImage} accessibilityRole="button">
-              {editAvatarUri ? (
-                <Image source={{ uri: editAvatarUri }} style={styles.avatarImage} />
-              ) : (
-                <LinearGradient
-                  colors={["#818CF8", "#6366F1", "#8B5CF6"]}
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 1 }}
-                  style={styles.avatarGradient}
-                >
-                  <Text style={styles.avatarInitial}>
-                    {user?.name?.charAt(0).toUpperCase() ?? "?"}
-                  </Text>
-                </LinearGradient>
-              )}
+              <UserAvatar
+                avatar={editAvatarValue}
+                name={editName.trim() || user?.name}
+                seed={user?.id ?? editName}
+                size={80}
+                style={styles.avatarFrame}
+              />
               <View style={styles.cameraBadge}>
-                <CameraIcon width={20} height={20} />
+                <CameraIcon width={14} height={14} />
               </View>
             </TouchableOpacity>
-            {editAvatarUri && (
+            {editAvatarValue && (
               <TouchableOpacity
                 style={styles.removeBadge}
                 onPress={handleRemoveAvatar}
                 accessibilityRole="button"
                 accessibilityLabel="Remove photo"
               >
-                <Feather name="x" size={16} color="#FFFFFF" />
+                <Feather name="x" size={13} color="#FFFFFF" />
               </TouchableOpacity>
             )}
           </View>
@@ -292,31 +243,12 @@ const styles = StyleSheet.create({
     position: "relative",
     marginBottom: 24,
   },
-<<<<<<< Updated upstream
   avatarFrame: {
     width: 80,
     height: 80,
     borderRadius: 80,
     borderWidth: 2,
     borderColor: "#E6E6E6",
-=======
-  avatarGradient: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  avatarImage: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-  },
-  avatarInitial: {
-    fontSize: 40,
-    color: "#FFFFFF",
-    fontFamily: typography.fontFamilyBold,
->>>>>>> Stashed changes
   },
   cameraBadge: {
     position: "absolute",

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import * as Haptics from "expo-haptics";
+import ScalePressable from "@components/ScalePressable";
 import {
   ActivityIndicator,
   LayoutAnimation,
@@ -59,6 +61,7 @@ type EventDetailsNavigation = NativeStackNavigationProp<
   RootStackParamList,
   "EventDetails" | "EventDetailsOverlay"
 >;
+
 
 const EventDetailsScreen = () => {
   const navigation = useNavigation<EventDetailsNavigation>();
@@ -508,10 +511,12 @@ const EventDetailsScreen = () => {
     if (isConversationMember) {
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setShowInvitePrompt((prev) => !prev);
   };
 
   const handleOpenChat = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     if (
       isOwner &&
       isSingleEvent &&
@@ -531,7 +536,7 @@ const EventDetailsScreen = () => {
       return;
     }
     setActiveConversation(eventConversation.id);
-    (navigation as any).navigate("ChatThread");
+    (navigation as any).push("ChatThread");
   };
 
   const renderAvatar = (
@@ -548,6 +553,7 @@ const EventDetailsScreen = () => {
 
   const handleAcceptRequest = async (request: ChatJoinRequest) => {
     if (!event || hostRequestStoreKey == null || eventNumericId == null) return;
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     setAcceptingUserId(request.userId);
     try {
       await approveJoinRequest(
@@ -574,6 +580,7 @@ const EventDetailsScreen = () => {
 
   const handleDeclineRequest = async (request: ChatJoinRequest) => {
     if (!event || hostRequestStoreKey == null || eventNumericId == null) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setDecliningUserId(request.userId);
     try {
       await denyJoinRequest(
@@ -606,8 +613,9 @@ const EventDetailsScreen = () => {
 
   const handleRequesterPress = async (request: ChatJoinRequest) => {
     if (!request.conversationId) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setActiveConversation(request.conversationId);
-    (navigation as any).navigate("ChatThread");
+    (navigation as any).push("ChatThread");
   };
 
   const openMemberMenu = (member: {
@@ -615,6 +623,7 @@ const EventDetailsScreen = () => {
     name: string;
     avatar?: string;
   }) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setSelectedMember(member);
     setShowMemberMenu(true);
   };
@@ -622,6 +631,7 @@ const EventDetailsScreen = () => {
   const handleRemoveMember = async () => {
     if (!event || !token || !selectedMember) return;
     if (isRemovingMember) return;
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     const removedMemberName = selectedMember.name;
     setRemoveError(null);
     setIsRemovingMember(true);
@@ -698,6 +708,7 @@ const EventDetailsScreen = () => {
       setReportError("Please tell us why you are reporting this member.");
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setReportError(null);
     setIsReportingMember(true);
     try {
@@ -777,6 +788,7 @@ const EventDetailsScreen = () => {
       setInviteError("Please include a brief note for the host.");
       return;
     }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     setInviteError(null);
     setIsSendingInvite(true);
     try {
@@ -852,6 +864,7 @@ const EventDetailsScreen = () => {
   const handleDeletePrompt = () => {
     setShowManagePrompt(false);
     setDeleteError(null);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     setShowDeleteConfirm(true);
   };
 
@@ -862,6 +875,7 @@ const EventDetailsScreen = () => {
     if (isDeleting) {
       return;
     }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     setDeleteError(null);
     setIsDeleting(true);
     setDisableHostRequestPolling(true);
@@ -903,6 +917,7 @@ const EventDetailsScreen = () => {
     if (isCancellingRequest) {
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setIsCancellingRequest(true);
     try {
       const response = await authFetch(
@@ -948,6 +963,7 @@ const EventDetailsScreen = () => {
       setReportError("Please tell us why you are reporting this event.");
       return;
     }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setReportError(null);
     setIsSubmittingReport(true);
     try {
@@ -1004,6 +1020,7 @@ const EventDetailsScreen = () => {
   };
 
   const handleLeavePrompt = () => afterMenuClose(() => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     setLeaveError(null);
     setShowLeaveConfirm(true);
   });
@@ -1015,6 +1032,7 @@ const EventDetailsScreen = () => {
     if (isLeaving) {
       return;
     }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     setLeaveError(null);
     setIsLeaving(true);
     try {
@@ -1079,6 +1097,7 @@ const EventDetailsScreen = () => {
   };
 
   const handleMenuReportEvent = () => afterMenuClose(() => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     setReportMessage("");
     setReportError(null);
     setShowReportPrompt(true);
@@ -1157,7 +1176,7 @@ const EventDetailsScreen = () => {
           <>
             <Pressable
               accessibilityRole="button"
-              onPress={navigation.goBack}
+              onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
               style={[styles.backButton, { top: insets.top + 10 }]}
             >
               <Feather
@@ -1168,7 +1187,10 @@ const EventDetailsScreen = () => {
             </Pressable>
             <Pressable
               accessibilityRole="button"
-              onPress={() => setShowMenuOverlay(true)}
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+                setShowMenuOverlay(true);
+              }}
               style={[styles.menuButton, { top: insets.top + 10 }]}
             >
               <Feather
@@ -1181,7 +1203,7 @@ const EventDetailsScreen = () => {
         ) : (
           <Pressable
             accessibilityRole="button"
-            onPress={navigation.goBack}
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
             hitSlop={12}
             style={[styles.overlayCloseButton, styles.overlayCloseButtonFixed]}
           >
@@ -1309,6 +1331,7 @@ const EventDetailsScreen = () => {
                 >
                   {event.description}
                 </Text>
+<<<<<<< Updated upstream
                 {descriptionHasMore && (
                   <Text
                     style={styles.seeMoreText}
@@ -1316,6 +1339,17 @@ const EventDetailsScreen = () => {
                   >
                     {descriptionExpanded ? "Show less" : "...See more"}
                   </Text>
+=======
+                {event.description.length > 100 && !descriptionExpanded && (
+                  <ScalePressable
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                      setDescriptionExpanded(true);
+                    }}
+                  >
+                    <Text style={styles.seeMoreText}>...See more</Text>
+                  </ScalePressable>
+>>>>>>> Stashed changes
                 )}
               </View>
             )}
@@ -1326,10 +1360,13 @@ const EventDetailsScreen = () => {
                 {/* Tabs header + divider as one unit to avoid card gap */}
                 <View>
                   <View style={styles.tabContainer}>
-                    <Pressable
+                    <ScalePressable
                       style={styles.tabItem}
                       hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-                      onPress={() => setActiveTab("requests")}
+                      onPress={() => {
+                        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                        setActiveTab("requests");
+                      }}
                     >
                       <View style={styles.tabLabelRow}>
                         <Text style={[styles.tabLabel, activeTab === "requests" && styles.tabLabelActive]}>
@@ -1340,13 +1377,16 @@ const EventDetailsScreen = () => {
                         </Text>
                       </View>
                       {activeTab === "requests" && <View style={styles.tabUnderline} />}
-                    </Pressable>
+                    </ScalePressable>
 
                     {isSingleEvent && (
-                      <Pressable
+                      <ScalePressable
                         style={styles.tabItem}
                         hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-                        onPress={() => setActiveTab("accepted")}
+                        onPress={() => {
+                          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                          setActiveTab("accepted");
+                        }}
                       >
                         <View style={styles.tabLabelRow}>
                           <Text style={[styles.tabLabel, activeTab === "accepted" && styles.tabLabelActive]}>
@@ -1357,14 +1397,17 @@ const EventDetailsScreen = () => {
                           </Text>
                         </View>
                         {activeTab === "accepted" && <View style={styles.tabUnderline} />}
-                      </Pressable>
+                      </ScalePressable>
                     )}
 
                     {activeTab !== "accepted" && !isSingleEvent && (
-                      <Pressable
+                      <ScalePressable
                         style={styles.tabItem}
                         hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-                        onPress={() => setActiveTab("members")}
+                        onPress={() => {
+                          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                          setActiveTab("members");
+                        }}
                       >
                         <View style={styles.tabLabelRow}>
                           <Text style={[styles.tabLabel, activeTab === "members" && styles.tabLabelActive]}>
@@ -1375,7 +1418,7 @@ const EventDetailsScreen = () => {
                           </Text>
                         </View>
                         {activeTab === "members" && <View style={styles.tabUnderline} />}
-                      </Pressable>
+                      </ScalePressable>
                     )}
                   </View>
                   <View style={[styles.divider, { marginVertical: 0 }]} />
@@ -1409,19 +1452,19 @@ const EventDetailsScreen = () => {
                                 {request.message}
                               </Text>
                               {!isExpanded && request.message.length > 100 && (
-                                <Text
-                                  style={styles.seeMoreText}
-                                  onPress={() =>
-                                    toggleRequestExpanded(request.id)
-                                  }
+                                <ScalePressable
+                                  onPress={() => {
+                                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                                    toggleRequestExpanded(request.id);
+                                  }}
                                 >
-                                  See more
-                                </Text>
+                                  <Text style={styles.seeMoreText}>See more</Text>
+                                </ScalePressable>
                               )}
                             </View>
 
                             <View style={styles.requestActions}>
-                              <Pressable
+                              <ScalePressable
                                 style={[
                                   styles.actionButton,
                                   styles.declineButton,
@@ -1441,9 +1484,9 @@ const EventDetailsScreen = () => {
                                     color={colors.text}
                                   />
                                 )}
-                              </Pressable>
+                              </ScalePressable>
 
-                              <Pressable
+                              <ScalePressable
                                 style={[
                                   styles.actionButton,
                                   styles.acceptButton,
@@ -1463,7 +1506,7 @@ const EventDetailsScreen = () => {
                                     color={colors.buttonText}
                                   />
                                 )}
-                              </Pressable>
+                              </ScalePressable>
                             </View>
                           </View>
                           {index < pendingRequests.length - 1 && (
@@ -1484,7 +1527,7 @@ const EventDetailsScreen = () => {
                       </Text>
                     ) : (
                       acceptedRequests.map((request) => (
-                        <Pressable
+                        <ScalePressable
                           key={request.id}
                           onPress={() => handleRequesterPress(request)}
                           style={styles.memberItem}
@@ -1493,11 +1536,8 @@ const EventDetailsScreen = () => {
                           <Text style={styles.memberName}>
                             {request.requester.name}
                           </Text>
-                          <Pressable
-                            onPress={(e) => {
-                              e.stopPropagation();
-                              openMemberMenu(request.requester);
-                            }}
+                          <ScalePressable
+                            onPress={() => openMemberMenu(request.requester)}
                             style={styles.requestMenuButton}
                           >
                             <Feather
@@ -1505,8 +1545,8 @@ const EventDetailsScreen = () => {
                               size={24}
                               color="#666"
                             />
-                          </Pressable>
-                        </Pressable>
+                          </ScalePressable>
+                        </ScalePressable>
                       ))
                     )}
                   </View>
@@ -1522,7 +1562,7 @@ const EventDetailsScreen = () => {
                         <View key={member.id} style={styles.memberItem}>
                           {renderAvatar(member)}
                           <Text style={styles.memberName}>{member.name}</Text>
-                          <Pressable
+                          <ScalePressable
                             onPress={() => openMemberMenu(member)}
                             style={styles.requestMenuButton}
                           >
@@ -1531,7 +1571,7 @@ const EventDetailsScreen = () => {
                               size={24}
                               color="#666"
                             />
-                          </Pressable>
+                          </ScalePressable>
                         </View>
                       ))
                     )}
@@ -1572,7 +1612,7 @@ const EventDetailsScreen = () => {
                           {member.id === user?.id && isOwner ? (
                             <Text style={styles.hostBadgeText}>Host</Text>
                           ) : isOwner && member.id !== user?.id ? (
-                            <Pressable
+                            <ScalePressable
                               onPress={() => openMemberMenu(member)}
                               style={styles.requestMenuButton}
                             >
@@ -1581,7 +1621,7 @@ const EventDetailsScreen = () => {
                                 size={24}
                                 color="#666"
                               />
-                            </Pressable>
+                            </ScalePressable>
                           ) : null}
                         </View>
                       ))
@@ -1615,27 +1655,23 @@ const EventDetailsScreen = () => {
                 { paddingBottom: insets.bottom + 4 },
               ]}
             >
-              <Pressable
-                accessibilityRole="button"
+              <ScalePressable
                 onPress={handleCtaPress}
-                style={({ pressed }) => [
-                  styles.ctaButton,
-                  pressed && styles.ctaButtonPressed,
-                  (shouldShowInvitePrompt || hasPendingRequest) &&
-                    styles.ctaButtonDisabled,
-                ]}
                 disabled={shouldShowInvitePrompt || hasPendingRequest}
+                style={[
+                  styles.ctaButton,
+                  (shouldShowInvitePrompt || hasPendingRequest) && styles.ctaButtonDisabled,
+                ]}
               >
                 <Text
                   style={[
                     styles.ctaLabel,
-                    (shouldShowInvitePrompt || hasPendingRequest) &&
-                      styles.ctaLabelDisabled,
+                    (shouldShowInvitePrompt || hasPendingRequest) && styles.ctaLabelDisabled,
                   ]}
                 >
                   {ctaLabel}
                 </Text>
-              </Pressable>
+              </ScalePressable>
             </View>
           </View>
         )}
@@ -1647,21 +1683,14 @@ const EventDetailsScreen = () => {
               style={StyleSheet.absoluteFill}
             />
             <View style={[styles.ctaContainer, { paddingBottom: insets.bottom + 4 }]}>
-              <Pressable
-                accessibilityRole="button"
+              <ScalePressable
                 onPress={handleOpenChat}
-                style={({ pressed }) => [
-                  styles.ctaButton,
-                  isOwner && styles.ctaButtonSecondary,
-                  pressed && styles.ctaButtonPressed,
-                ]}
+                style={[styles.ctaButton, isOwner && styles.ctaButtonSecondary]}
               >
-                <Text
-                  style={[styles.ctaLabel, isOwner && styles.ctaLabelSecondary]}
-                >
+                <Text style={[styles.ctaLabel, isOwner && styles.ctaLabelSecondary]}>
                   Go to Chat
                 </Text>
-              </Pressable>
+              </ScalePressable>
             </View>
           </View>
         ) : null}

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -1331,25 +1331,16 @@ const EventDetailsScreen = () => {
                 >
                   {event.description}
                 </Text>
-<<<<<<< Updated upstream
                 {descriptionHasMore && (
                   <Text
                     style={styles.seeMoreText}
-                    onPress={() => setDescriptionExpanded((prev) => !prev)}
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                      setDescriptionExpanded((prev) => !prev);
+                    }}
                   >
                     {descriptionExpanded ? "Show less" : "...See more"}
                   </Text>
-=======
-                {event.description.length > 100 && !descriptionExpanded && (
-                  <ScalePressable
-                    onPress={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                      setDescriptionExpanded(true);
-                    }}
-                  >
-                    <Text style={styles.seeMoreText}>...See more</Text>
-                  </ScalePressable>
->>>>>>> Stashed changes
                 )}
               </View>
             )}

--- a/src/screens/GoogleSignIn.tsx
+++ b/src/screens/GoogleSignIn.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
-  Button,
   Platform,
+  Pressable,
   StyleSheet,
   Text,
   View,
@@ -19,6 +19,8 @@ import { colors, spacing, typography } from "@theme/index";
 import { GOOGLE_WEB_CLIENT_ID, GOOGLE_IOS_CLIENT_ID } from "@constants/google";
 import { APPLE_SIGNIN_DEV_ALL_PLATFORMS } from "@constants/featureFlags";
 import ScreenContainer from "@components/ScreenContainer";
+import GoogleLogo from "@assets/google-logo.svg";
+import AppleLogo from "@assets/apple-logo.svg";
 
 const GoogleSignInScreen = () => {
   const navigation =
@@ -208,7 +210,7 @@ const GoogleSignInScreen = () => {
   return (
     <ScreenContainer>
       <View style={styles.container}>
-        <Text style={styles.heading}>Sign in with Google</Text>
+        <Text style={styles.heading}>Sign in</Text>
         <Text
           style={[
             styles.helper,
@@ -219,28 +221,52 @@ const GoogleSignInScreen = () => {
         </Text>
 
         <View style={styles.buttonGroup}>
-          <Button
-            title={isSigningIn ? "Signing in..." : "Sign in with Google"}
+          <Pressable
+            style={({ pressed }) => [
+              styles.button,
+              isSigningIn && styles.buttonDisabled,
+              pressed && !isSigningIn && styles.buttonPressed,
+            ]}
             onPress={onGooglePress}
             disabled={isSigningIn}
             testID="google-sign-in-button"
-          />
+            accessibilityRole="button"
+          >
+            <View style={styles.iconWrapper}>
+              {isSigningIn ? (
+                <ActivityIndicator color="#FFFFFF" size="small" />
+              ) : (
+                <GoogleLogo width={20} height={20} />
+              )}
+            </View>
+            <Text style={styles.buttonText}>
+              {isSigningIn ? "Signing in…" : "Continue with Google"}
+            </Text>
+          </Pressable>
 
           {shouldShowAppleButton ? (
-            <Button
-              title={isSigningIn ? "Signing in..." : "Sign in with Apple"}
+            <Pressable
+              style={({ pressed }) => [
+                styles.button,
+                isSigningIn && styles.buttonDisabled,
+                pressed && !isSigningIn && styles.buttonPressed,
+              ]}
               onPress={onApplePress}
               disabled={isSigningIn}
               testID="apple-sign-in-button"
-            />
+              accessibilityRole="button"
+            >
+              <View style={styles.iconWrapper}>
+                <AppleLogo width={20} height={20} />
+              </View>
+              <Text style={styles.buttonText}>Continue with Apple</Text>
+            </Pressable>
           ) : null}
         </View>
 
         {appleHelperText ? (
           <Text style={styles.helper}>{appleHelperText}</Text>
         ) : null}
-
-        {isSigningIn ? <ActivityIndicator color={colors.subText} /> : null}
       </View>
     </ScreenContainer>
   );
@@ -269,7 +295,35 @@ const styles = StyleSheet.create({
     color: "#B00020",
   },
   buttonGroup: {
-    gap: spacing.md,
+    gap: 12,
+  },
+  button: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 52,
+    borderRadius: 26,
+    borderCurve: "continuous",
+    backgroundColor: "#000000",
+    paddingHorizontal: 16,
+  },
+  iconWrapper: {
+    position: "absolute",
+    left: 16,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    flex: 1,
+    textAlign: "center",
+    fontSize: 16,
+    fontFamily: typography.fontFamilyMedium,
+    color: "#FFFFFF",
+    lineHeight: 20,
+    letterSpacing: -0.3,
   },
 });
 

--- a/src/screens/HelpScreen.tsx
+++ b/src/screens/HelpScreen.tsx
@@ -1,4 +1,5 @@
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import * as Haptics from "expo-haptics";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
@@ -20,7 +21,7 @@ const HelpScreen = () => {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Go back"
-          onPress={() => navigation.goBack()}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
           style={styles.backButton}
           hitSlop={8}
         >

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,19 +3,16 @@ import {
   ActivityIndicator,
   Pressable,
   RefreshControl,
-  ScrollView,
   SectionList,
   SectionListRenderItemInfo,
   StyleSheet,
   Text,
   View,
 } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
-import PagerView from "react-native-pager-view";
+import AnimatedPager from "@components/AnimatedPager";
+import ScalePressable from "@components/ScalePressable";
+import * as Haptics from "expo-haptics";
+import { useSharedValue } from "react-native-reanimated";
 import {
   useNavigation,
   useRoute,
@@ -99,24 +96,11 @@ type EventCardItemProps = {
   onPress: () => void;
 };
 
-const EventCardItem = memo(({ item, onPress }: EventCardItemProps) => {
-  const scale = useSharedValue(1);
-  const animStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => { scale.value = withSpring(0.96, { damping: 40, stiffness: 600, mass: 0.3 }); }}
-      onPressOut={() => { scale.value = withSpring(1, { damping: 15, stiffness: 300, mass: 0.3 }); }}
-    >
-      <Animated.View style={animStyle}>
-        <EventCard {...item} />
-      </Animated.View>
-    </Pressable>
-  );
-});
+const EventCardItem = memo(({ item, onPress }: EventCardItemProps) => (
+  <ScalePressable onPress={onPress} delay={80}>
+    <EventCard {...item} />
+  </ScalePressable>
+));
 
 const sortOptions = [
   { label: "Upcoming", value: "upcoming" },
@@ -143,8 +127,8 @@ const HomeScreen = () => {
   const { conversations } = useChat();
   const isFocused = useIsFocused();
   const insets = useSafeAreaInsets();
-  const pagerRef = useRef<PagerView>(null);
   const [selectedPage, setSelectedPage] = useState(0);
+  const pageOffset = useSharedValue(0);
   const [headerHeight, setHeaderHeight] = useState(0);
   const hasLoadedOnce = useRef(false);
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
@@ -154,17 +138,20 @@ const HomeScreen = () => {
 
   useEffect(() => {
     if (!route.params?.showEventReportedBadge) return;
-    setShowReportedBadge(true);
+    const t = setTimeout(() => setShowReportedBadge(true), 350);
+    return () => clearTimeout(t);
   }, [route.params?.showEventReportedBadge]);
 
   useEffect(() => {
     if (!route.params?.showEventDeletedBadge) return;
-    setShowEventDeletedBadge(true);
+    const t = setTimeout(() => setShowEventDeletedBadge(true), 350);
+    return () => clearTimeout(t);
   }, [route.params?.showEventDeletedBadge]);
 
   useEffect(() => {
     if (!route.params?.showEventLeftBadge) return;
-    setShowEventLeftBadge(true);
+    const t = setTimeout(() => setShowEventLeftBadge(true), 350);
+    return () => clearTimeout(t);
   }, [route.params?.showEventLeftBadge]);
 
   // Set of event IDs user has joined (is a member of conversation but not owner)
@@ -245,12 +232,13 @@ const HomeScreen = () => {
   const renderItem = ({ item }: SectionListRenderItemInfo<EventItemProps>) => (
     <EventCardItem
       item={item}
-      onPress={() =>
+      onPress={() => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         navigation.navigate("EventDetails", {
           eventId: item.id,
           origin: "Events",
-        })
-      }
+        });
+      }}
     />
   );
 
@@ -264,23 +252,18 @@ const HomeScreen = () => {
         ) : showAllEventsError ? (
           <View style={[styles.centerContent, { paddingTop: headerHeight }]}>
             <Text style={styles.errorText}>{error}</Text>
-            <Pressable style={styles.retryButton} onPress={handleRefresh}>
+            <Pressable style={styles.retryButton} onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); handleRefresh(); }}>
               <Text style={styles.retryButtonText}>Try again</Text>
             </Pressable>
           </View>
         ) : (
-          <PagerView
-            ref={pagerRef}
+          <AnimatedPager
+            selectedIndex={selectedPage}
+            onPageChange={setSelectedPage}
+            pageOffsetSV={pageOffset}
             style={styles.pager}
-            initialPage={0}
-            onPageSelected={(e) => setSelectedPage(e.nativeEvent.position)}
-            onPageScroll={(e) => {
-              const { position, offset } = e.nativeEvent;
-              if (offset > 0.5) setSelectedPage(position + 1);
-              else setSelectedPage(position);
-            }}
           >
-            <View key="upcoming" style={{ flex: 1 }}>
+            <View style={{ flex: 1 }}>
               <SectionList<EventItemProps, EventSection>
                 sections={upcomingSections}
                 keyExtractor={(item) => item.id}
@@ -292,11 +275,11 @@ const HomeScreen = () => {
                 SectionSeparatorComponent={({ leadingItem }) => leadingItem ? <View style={styles.sectionSeparator} /> : null}
                 ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
                 ListFooterComponent={<View style={styles.footerSpacing} />}
-                ListEmptyComponent={showAllEventsEmpty ? <View style={[styles.centerContent, { paddingTop: headerHeight }]}><EmptyState title="Nothing Happening Here (Yet!)" description={"There are currently no events available.\nPlease check back later."} imageSource={require('@assets/emptystate_discoverevent.png')} /></View> : null}
+                ListEmptyComponent={showAllEventsEmpty ? <View style={[styles.centerContent, { paddingTop: headerHeight }]}><EmptyState title="Nothing Happening Here (Yet!)" description={"There are currently no events available. Please check back later."} imageSource={require('@assets/emptystate_discoverevent.png')} /></View> : null}
                 refreshControl={<RefreshControl refreshing={isPullRefreshing} onRefresh={handleRefresh} tintColor={colors.primary} />}
               />
             </View>
-            <View key="newest" style={{ flex: 1 }}>
+            <View style={{ flex: 1 }}>
               <SectionList<EventItemProps, EventSection>
                 sections={newestSections}
                 keyExtractor={(item) => item.id}
@@ -308,11 +291,11 @@ const HomeScreen = () => {
                 SectionSeparatorComponent={({ leadingItem }) => leadingItem ? <View style={styles.sectionSeparator} /> : null}
                 ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
                 ListFooterComponent={<View style={styles.footerSpacing} />}
-                ListEmptyComponent={showAllEventsEmpty ? <View style={[styles.centerContent, { paddingTop: headerHeight }]}><EmptyState title="Nothing Happening Here (Yet!)" description={"There are currently no events available.\nPlease check back later."} imageSource={require('@assets/emptystate_discoverevent.png')} /></View> : null}
+                ListEmptyComponent={showAllEventsEmpty ? <View style={[styles.centerContent, { paddingTop: headerHeight }]}><EmptyState title="Nothing Happening Here (Yet!)" description={"There are currently no events available. Please check back later."} imageSource={require('@assets/emptystate_discoverevent.png')} /></View> : null}
                 refreshControl={<RefreshControl refreshing={isPullRefreshing} onRefresh={handleRefresh} tintColor={colors.primary} />}
               />
             </View>
-          </PagerView>
+          </AnimatedPager>
         )}
         {/* Floating header */}
         <View
@@ -329,8 +312,8 @@ const HomeScreen = () => {
               onChange={(value) => {
                 const index = sortOptions.findIndex((o) => o.value === value);
                 setSelectedPage(index);
-                pagerRef.current?.setPage(index);
               }}
+              pageOffset={pageOffset}
             />
           </View>
         </View>

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -11,6 +11,8 @@ import { RouteProp, useFocusEffect, useNavigation, useRoute } from "@react-navig
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
 
+import * as Haptics from "expo-haptics";
+
 import { colors, spacing, typography } from "@theme/index";
 import { useChat, ChatJoinRequest } from "@context/ChatContext";
 import { useAuth } from "@context/AuthContext";
@@ -152,14 +154,16 @@ const JoinRequestsScreen = () => {
   const handleRequesterPress = useCallback(
     async (request: ChatJoinRequest & { conversationId?: number }) => {
       if (request.status !== "approved" || !request.conversationId) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       setActiveConversation(request.conversationId);
-      navigation.navigate("ChatThread");
+      (navigation as any).push("ChatThread");
     },
     [navigation, setActiveConversation],
   );
 
   // 1:1 mode: handle 3-dot menu press
   const handleMenuPress = useCallback((request: ChatJoinRequest) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setSelectedRequest(request);
     setShowRequestMenu(true);
   }, []);
@@ -340,27 +344,29 @@ const JoinRequestsScreen = () => {
   const render1to1Header = () => {
     return (
       <ChatEventHeader
-        onBack={() => navigation.goBack()}
+        onBack={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
         title={resolvedTitle}
         subtitle={resolvedSubtitle}
         coverSource={getCoverSource(resolvedCoverKey)}
-        onTitlePress={() =>
+        onTitlePress={() => {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           navigation.navigate("EventDetailsOverlay", {
             eventId: String(eventId),
             readOnly: true,
-          })
-        }
+          });
+        }}
         rightElement={
           pendingRequests.length > 0 ? (
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="View pending requests"
-              onPress={() =>
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 navigation.navigate("PendingRequests", {
                   conversationId,
                   eventId,
-                })
-              }
+                });
+              }}
               style={styles.joinIconButton}
             >
               <Feather name="users" size={20} color={colors.text} />
@@ -425,15 +431,16 @@ const JoinRequestsScreen = () => {
   // Group mode header
   const renderGroupHeader = () => (
     <ChatEventHeader
-      onBack={() => navigation.goBack()}
+      onBack={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
       title={resolvedTitle}
       subtitle="Join Requests"
-      onTitlePress={() =>
+      onTitlePress={() => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         navigation.navigate("EventDetailsOverlay", {
           eventId: String(eventId),
           readOnly: true,
-        })
-      }
+        });
+      }}
       testID="join-requests-group-event-info-button"
     />
   );
@@ -456,13 +463,13 @@ const JoinRequestsScreen = () => {
         </View>
         <View style={styles.requestActions}>
           <Pressable
-            onPress={() => handleAction(item.id, item.userId, "deny")}
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); handleAction(item.id, item.userId, "deny"); }}
             style={styles.declineButton}
           >
             <Feather name="x" size={18} color={colors.text} />
           </Pressable>
           <Pressable
-            onPress={() => handleAction(item.id, item.userId, "approve")}
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); handleAction(item.id, item.userId, "approve"); }}
             style={styles.acceptButton}
           >
             <Feather name="check" size={18} color={colors.buttonText} />

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -1,14 +1,14 @@
 import {
   FlatList,
-  Pressable,
   RefreshControl,
   StyleSheet,
   Text,
   View,
 } from "react-native";
 import { Image } from "expo-image";
+import * as Haptics from "expo-haptics";
 import { useCallback, useMemo, useState } from "react";
-import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
+import ScalePressable from "@components/ScalePressable";
 import BottomSheetModal from "@components/BottomSheetModal";
 import SignInButtons from "@components/SignInButtons";
 import {
@@ -48,9 +48,6 @@ const ConversationRow = ({
   events: { id: string; imageUri: string }[];
   userId?: number;
 }) => {
-  const scale = useSharedValue(1);
-  const animStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
-
   const { participants = [] } = item;
   const counterpart =
     participants.find((p) => p.id !== userId) ?? participants[0];
@@ -75,18 +72,11 @@ const ConversationRow = ({
   const avatarSeed = isGroup ? titleLabel : (counterpart?.id ?? titleLabel);
 
   return (
-    <Pressable
+    <ScalePressable
       onPress={() => onPress(item)}
-      onPressIn={() => { scale.value = withSpring(0.96, { damping: 40, stiffness: 600, mass: 0.3 }); }}
-      onPressOut={() => { scale.value = withSpring(1, { damping: 15, stiffness: 300, mass: 0.3 }); }}
+      onPressIn={() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)}
+      style={[styles.conversationRow, item.id === activeConversationId && styles.conversationRowActive]}
     >
-      <Animated.View
-        style={[
-          animStyle,
-          styles.conversationRow,
-          item.id === activeConversationId && styles.conversationRowActive,
-        ]}
-      >
         {hasUnread && <View testID={`conversation-unread-dot-${item.id}`} style={styles.unreadDot} />}
         <View style={styles.conversationAvatar}>
           {eventImageUri ? (
@@ -108,9 +98,8 @@ const ConversationRow = ({
             {previewText}
           </Text>
         </View>
-      </Animated.View>
       <View style={styles.conversationDivider} />
-    </Pressable>
+    </ScalePressable>
   );
 };
 
@@ -228,7 +217,7 @@ const MessagesScreen = () => {
         </View>
         <EmptyState
           title="No messages to show"
-          description={"Sign in to view conversations from\nevents you've created or joined"}
+          description={"Sign in to view conversations from events you've created or joined"}
           actionLabel="Continue"
           onActionPress={() => setSignInVisible(true)}
           imageSource={require('@assets/emptystate_chat.png')}
@@ -261,7 +250,7 @@ const MessagesScreen = () => {
             !isRefreshingConversations && !isConnecting ? (
               <EmptyState
                 title="No Messages Yet"
-                description={"Messages from your events\nwill appear here"}
+                description={"Messages from your events will appear here"}
                 imageSource={require('@assets/emptystate_chat.png')}
               />
             ) : null

--- a/src/screens/MyEventsScreen.tsx
+++ b/src/screens/MyEventsScreen.tsx
@@ -1,22 +1,19 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import * as Haptics from "expo-haptics";
 import BottomSheetModal from "@components/BottomSheetModal";
 import SignInButtons from "@components/SignInButtons";
+import SegmentedControl, { SegmentedOption } from "@components/SegmentedControl";
 import {
-  Pressable,
   RefreshControl,
-  ScrollView,
   SectionList,
   SectionListRenderItemInfo,
   StyleSheet,
   Text,
   View,
 } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from "react-native-reanimated";
-import PagerView from "react-native-pager-view";
+import AnimatedPager from "@components/AnimatedPager";
+import ScalePressable from "@components/ScalePressable";
+import { useSharedValue } from "react-native-reanimated";
 
 import {
   BottomTabNavigationProp,
@@ -76,23 +73,11 @@ const buildSections = (items: EventItemProps[]): EventSection[] => {
     .filter((s) => s.data.length > 0);
 };
 
-const EventCardItem = memo(({ item, onPress }: { item: EventItemProps; onPress: () => void }) => {
-  const scale = useSharedValue(1);
-  const animStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => { scale.value = withSpring(0.96, { damping: 40, stiffness: 600, mass: 0.3 }); }}
-      onPressOut={() => { scale.value = withSpring(1, { damping: 15, stiffness: 300, mass: 0.3 }); }}
-    >
-      <Animated.View style={animStyle}>
-        <EventCard {...item} />
-      </Animated.View>
-    </Pressable>
-  );
-});
+const EventCardItem = memo(({ item, onPress }: { item: EventItemProps; onPress: () => void }) => (
+  <ScalePressable onPress={onPress} delay={80}>
+    <EventCard {...item} />
+  </ScalePressable>
+));
 
 const toEventCardItem = (event: UserEvent, badgeLabel: string): EventItemProps => ({
   ...event,
@@ -119,8 +104,8 @@ const MyEventsScreen = () => {
   const { user } = useAuth();
   const insets = useSafeAreaInsets();
 
-  const pagerRef = useRef<PagerView>(null);
   const [selectedPage, setSelectedPage] = useState(0);
+  const pageOffset = useSharedValue(0);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isRequestedRefreshing, setIsRequestedRefreshing] = useState(false);
@@ -129,12 +114,14 @@ const MyEventsScreen = () => {
 
   useEffect(() => {
     if (!route.params?.showEventCreatedBadge) return;
-    setShowEventCreatedBadge(true);
+    const t = setTimeout(() => setShowEventCreatedBadge(true), 350);
+    return () => clearTimeout(t);
   }, [route.params?.showEventCreatedBadge]);
 
   useEffect(() => {
     if (!route.params?.showEventDeletedBadge) return;
-    setShowEventDeletedBadge(true);
+    const t = setTimeout(() => setShowEventDeletedBadge(true), 350);
+    return () => clearTimeout(t);
   }, [route.params?.showEventDeletedBadge]);
 
   const joinedEventIds = useMemo(() => {
@@ -194,14 +181,17 @@ const MyEventsScreen = () => {
   const renderItem = ({ item }: SectionListRenderItemInfo<EventItemProps>) => (
     <EventCardItem
       item={item}
-      onPress={() => navigation.navigate("EventDetails", { eventId: item.id, origin: "MyEvents" })}
+      onPress={() => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        navigation.navigate("EventDetails", { eventId: item.id, origin: "MyEvents" });
+      }}
     />
   );
 
-  const filterOptions = [
-    { label: "Hosting", count: counts.hosting },
-    { label: "Joined", count: counts.joined },
-    { label: "Requested", count: counts.requested },
+  const filterOptions: SegmentedOption[] = [
+    { label: "Hosting", value: "hosting", count: counts.hosting },
+    { label: "Joined", value: "joined", count: counts.joined },
+    { label: "Requested", value: "requested", count: counts.requested },
   ];
 
   const listContentStyle = [
@@ -219,7 +209,7 @@ const MyEventsScreen = () => {
         </View>
         <EmptyState
           title="No events to show"
-          description={"Sign in to see the events you've\ncreated or joined"}
+          description={"Sign in to see the events you've created or joined"}
           actionLabel="Continue"
           onActionPress={() => setSignInVisible(true)}
           imageSource={require('@assets/emptystate_myevent.png')}
@@ -234,19 +224,14 @@ const MyEventsScreen = () => {
   return (
     <ScreenContainer>
       <View style={styles.content}>
-        <PagerView
-          ref={pagerRef}
+        <AnimatedPager
+          selectedIndex={selectedPage}
+          onPageChange={setSelectedPage}
+          pageOffsetSV={pageOffset}
           style={styles.pager}
-          initialPage={0}
-          onPageSelected={(e) => setSelectedPage(e.nativeEvent.position)}
-          onPageScroll={(e) => {
-            const { position, offset } = e.nativeEvent;
-            if (offset > 0.5) setSelectedPage(position + 1);
-            else setSelectedPage(position);
-          }}
         >
           {/* Page 0: Hosting */}
-          <View key="hosting" style={{ flex: 1 }}>
+          <View style={{ flex: 1 }}>
             <SectionList<EventItemProps, EventSection>
               sections={hostingSections}
               keyExtractor={(item) => item.id}
@@ -258,13 +243,13 @@ const MyEventsScreen = () => {
               SectionSeparatorComponent={({ leadingItem }) => leadingItem ? <View style={styles.sectionSeparator} /> : null}
               ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
               ListFooterComponent={<View style={styles.footerSpacing} />}
-              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you host\nwill appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
+              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you host will appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
               refreshControl={<RefreshControl refreshing={selectedPage === 0 ? isRefreshing : false} onRefresh={handleRefresh} tintColor={colors.primary} />}
             />
           </View>
 
           {/* Page 1: Joined */}
-          <View key="joined" style={{ flex: 1 }}>
+          <View style={{ flex: 1 }}>
             <SectionList<EventItemProps, EventSection>
               sections={joinedSections}
               keyExtractor={(item) => item.id}
@@ -276,13 +261,13 @@ const MyEventsScreen = () => {
               SectionSeparatorComponent={({ leadingItem }) => leadingItem ? <View style={styles.sectionSeparator} /> : null}
               ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
               ListFooterComponent={<View style={styles.footerSpacing} />}
-              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you join\nwill appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
+              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you join will appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
               refreshControl={<RefreshControl refreshing={selectedPage === 1 ? isRefreshing : false} onRefresh={handleRefresh} tintColor={colors.primary} />}
             />
           </View>
 
           {/* Page 2: Requested */}
-          <View key="requested" style={{ flex: 1 }}>
+          <View style={{ flex: 1 }}>
             <SectionList<EventItemProps, EventSection>
               sections={requestedSections}
               keyExtractor={(item) => item.id}
@@ -294,11 +279,11 @@ const MyEventsScreen = () => {
               SectionSeparatorComponent={({ leadingItem }) => leadingItem ? <View style={styles.sectionSeparator} /> : null}
               ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
               ListFooterComponent={<View style={styles.footerSpacing} />}
-              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you request to join\nwill appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
+              ListEmptyComponent={<EmptyState title="No events yet" description={"Events you request to join will appear here"} imageSource={require('@assets/emptystate_myevent.png')} />}
               refreshControl={<RefreshControl refreshing={isRequestedRefreshing} onRefresh={handleRefresh} tintColor={colors.primary} />}
             />
           </View>
-        </PagerView>
+        </AnimatedPager>
 
         {/* Floating blurred header */}
         <View
@@ -308,35 +293,17 @@ const MyEventsScreen = () => {
           <View style={styles.headerSpacing}>
             <Text style={styles.headerTitle}>My Events</Text>
           </View>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.filterScrollContent}
-            style={styles.filterScrollView}
-          >
-            {filterOptions.map(({ label, count }, index) => {
-              const isSelected = index === selectedPage;
-              return (
-                <Pressable
-                  key={label}
-                  onPress={() => { setSelectedPage(index); pagerRef.current?.setPage(index); }}
-                  style={({ pressed }) => [
-                    styles.filterButton,
-                    (isSelected || pressed) && styles.filterButtonActive,
-                  ]}
-                >
-                  <Text style={[styles.filterButtonText, isSelected && styles.filterButtonTextActive]}>
-                    {label}
-                  </Text>
-                  {count > 0 && (
-                    <Text style={[styles.filterCountText, isSelected && styles.filterCountTextActive]}>
-                      {count}
-                    </Text>
-                  )}
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+          <View style={styles.filterRow}>
+            <SegmentedControl
+              options={filterOptions}
+              value={filterOptions[selectedPage].value}
+              onChange={(value) => {
+                const index = filterOptions.findIndex((o) => o.value === value);
+                setSelectedPage(index);
+              }}
+              pageOffset={pageOffset}
+            />
+          </View>
         </View>
 
         <EventActionBadge
@@ -388,51 +355,8 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight,
     letterSpacing: typography.letterSpacing,
   },
-  filterScrollView: {
-    flexGrow: 0,
-    flexShrink: 0,
+  filterRow: {
     marginBottom: spacing.md,
-  },
-  filterScrollContent: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.xs,
-    paddingRight: spacing.md,
-  },
-  filterButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    borderRadius: 10,
-    paddingVertical: 8,
-    paddingHorizontal: 10,
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    borderColor: "#E6E6E6",
-  },
-  filterButtonActive: {
-    backgroundColor: "#E6E6E6",
-    borderColor: "#E6E6E6",
-  },
-  filterButtonText: {
-    fontSize: 15,
-    fontFamily: typography.fontFamilyMedium,
-    color: "#494949",
-    lineHeight: 20,
-    letterSpacing: -0.3,
-  },
-  filterButtonTextActive: {
-    color: "#000000",
-  },
-  filterCountText: {
-    fontSize: 15,
-    fontFamily: typography.fontFamilyMedium,
-    color: "#808080",
-    lineHeight: 20,
-    letterSpacing: -0.3,
-  },
-  filterCountTextActive: {
-    color: "#000000",
   },
   listContent: {
     paddingHorizontal: spacing.md,

--- a/src/screens/PastEventsScreen.tsx
+++ b/src/screens/PastEventsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, memo } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -10,6 +10,8 @@ import {
   Text,
   View,
 } from "react-native";
+import ScalePressable from "@components/ScalePressable";
+import * as Haptics from "expo-haptics";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
@@ -22,6 +24,7 @@ import { useAuth } from "@context/AuthContext";
 import { API_BASE_URL } from "@api/config";
 import { CoverKey, resolveCoverUri } from "@constants/covers";
 import { RootStackParamList } from "@navigation/types";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   formatAbsoluteDateLabel,
   getScheduleDisplay,
@@ -89,9 +92,16 @@ const buildPastSections = (items: PastEventItem[]): PastEventSection[] => {
     .filter((section) => section.data.length > 0);
 };
 
+const EventCardItem = memo(({ item, onPress }: { item: PastEventItem; onPress: () => void }) => (
+  <ScalePressable onPress={onPress} delay={80}>
+    <EventCard {...item} />
+  </ScalePressable>
+));
+
 const PastEventsScreen = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { bottom: safeBottom } = useSafeAreaInsets();
   const { user, token, authFetch } = useAuth();
   const isFocused = useIsFocused();
   const [events, setEvents] = useState<PastEventItem[]>([]);
@@ -159,9 +169,13 @@ const PastEventsScreen = () => {
   );
 
   const renderItem = ({ item }: SectionListRenderItemInfo<PastEventItem>) => (
-    <View style={styles.eventPressable}>
-      <EventCard {...item} />
-    </View>
+    <EventCardItem
+      item={item}
+      onPress={() => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        navigation.navigate("EventDetails", { eventId: item.id });
+      }}
+    />
   );
 
   const showLoading = isLoading && events.length === 0;
@@ -169,12 +183,12 @@ const PastEventsScreen = () => {
   const showEmpty = !isLoading && events.length === 0 && !error;
 
   return (
-    <ScreenContainer>
+    <ScreenContainer edges={["top"]}>
       <View style={styles.header}>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Go back"
-          onPress={() => navigation.goBack()}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
           style={styles.backButton}
           hitSlop={8}
         >
@@ -218,7 +232,7 @@ const PastEventsScreen = () => {
           renderSectionHeader={renderSectionHeader}
           stickySectionHeadersEnabled={false}
           showsVerticalScrollIndicator={false}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, { paddingBottom: safeBottom }]}
           SectionSeparatorComponent={({ leadingItem }) =>
             leadingItem ? <View style={styles.sectionSeparator} /> : null
           }
@@ -255,21 +269,19 @@ const styles = StyleSheet.create({
     color: colors.text,
     letterSpacing: -0.4,
   },
-  listContent: {
-    paddingBottom: spacing.xl,
-  },
+  listContent: {},
   sectionHeader: {
-    fontSize: 16,
-    color: "#000000",
+    fontSize: 15,
+    color: '#808080',
     marginTop: 0,
-    marginBottom: 14,
+    marginBottom: 12,
     fontFamily: typography.fontFamilyMedium,
     flexShrink: 1,
     lineHeight: 20,
-    letterSpacing: -0.4,
+    letterSpacing: -0.3,
   },
   sectionSeparator: {
-    height: 28,
+    height: 22,
   },
   itemSeparator: {
     height: 14,
@@ -299,12 +311,6 @@ const styles = StyleSheet.create({
     fontFamily: typography.fontFamilyMedium,
     lineHeight: typography.lineHeight,
     letterSpacing: typography.letterSpacing,
-  },
-  eventPressable: {
-    borderRadius: 20,
-  },
-  eventPressablePressed: {
-    opacity: 0.85,
   },
 });
 

--- a/src/screens/PendingRequestsScreen.tsx
+++ b/src/screens/PendingRequestsScreen.tsx
@@ -12,6 +12,8 @@ import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
 
+import * as Haptics from "expo-haptics";
+
 import { colors, spacing, typography } from "@theme/index";
 import { useChat, ChatJoinRequest } from "@context/ChatContext";
 import { RootStackParamList } from "@navigation/types";
@@ -109,7 +111,7 @@ const PendingRequestsScreen = () => {
           </Text>
           <Pressable
             accessibilityRole="button"
-            onPress={() => navigation.goBack()}
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
             style={styles.closeButton}
             hitSlop={12}
           >
@@ -159,7 +161,7 @@ const PendingRequestsScreen = () => {
                       {!isExpanded && item.message.length > 100 && (
                         <Text
                           style={styles.seeMoreText}
-                          onPress={() => toggleRequestExpanded(item.id)}
+                          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); toggleRequestExpanded(item.id); }}
                         >
                           See more
                         </Text>
@@ -169,7 +171,7 @@ const PendingRequestsScreen = () => {
                     <View style={styles.requestActions}>
                       <Pressable
                         style={[styles.actionButton, styles.declineButton]}
-                        onPress={() => handleDecline(item)}
+                        onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium); handleDecline(item); }}
                         disabled={isLoading}
                         accessibilityRole="button"
                         accessibilityLabel="Decline request"
@@ -183,7 +185,7 @@ const PendingRequestsScreen = () => {
 
                       <Pressable
                         style={[styles.actionButton, styles.acceptButton]}
-                        onPress={() => handleAccept(item)}
+                        onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); handleAccept(item); }}
                         disabled={isLoading}
                         accessibilityRole="button"
                         accessibilityLabel="Accept request"

--- a/src/screens/PrivacyPolicyScreen.tsx
+++ b/src/screens/PrivacyPolicyScreen.tsx
@@ -1,4 +1,5 @@
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import * as Haptics from "expo-haptics";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Feather } from "@expo/vector-icons";
@@ -20,7 +21,7 @@ const PrivacyPolicyScreen = () => {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Go back"
-          onPress={() => navigation.goBack()}
+          onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
           style={styles.backButton}
           hitSlop={8}
         >

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,14 +1,19 @@
 import {
   Alert,
+<<<<<<< Updated upstream
   Animated,
+=======
+  Image,
+>>>>>>> Stashed changes
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   View,
 } from "react-native";
+import ScalePressable from "@components/ScalePressable";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   CompositeNavigationProp,
   useNavigation,
@@ -45,6 +50,7 @@ interface MenuItemProps {
   label: string;
   onPress: () => void;
   showChevron?: boolean;
+  haptic?: "light" | "medium" | "warning";
 }
 
 const MenuItem = ({
@@ -52,13 +58,21 @@ const MenuItem = ({
   label,
   onPress,
   showChevron = true,
+  haptic = "light",
 }: MenuItemProps) => {
+  const handlePress = () => {
+    if (haptic === "warning") {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    } else if (haptic === "medium") {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    } else {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    onPress();
+  };
+
   return (
-    <Pressable
-      style={styles.menuItem}
-      onPress={onPress}
-      accessibilityRole="button"
-    >
+    <ScalePressable pressableStyle={styles.menuItem} style={styles.menuItemInner} onPress={handlePress}>
       <View style={styles.menuItemLeft}>
         <View style={styles.menuIconContainer}>
           {icon}
@@ -68,7 +82,7 @@ const MenuItem = ({
       {showChevron && (
         <Feather name="chevron-right" size={20} color="#808080" />
       )}
-    </Pressable>
+    </ScalePressable>
   );
 };
 
@@ -134,24 +148,6 @@ const ProfileScreen = () => {
     Alert.alert("Delete Account", "Coming Soon");
   }, []);
 
-  const scaleAnim = useRef(new Animated.Value(1)).current;
-
-  const handlePressIn = useCallback(() => {
-    Animated.timing(scaleAnim, {
-      toValue: 0.97,
-      duration: 100,
-      useNativeDriver: true,
-    }).start();
-  }, [scaleAnim]);
-
-  const handlePressOut = useCallback(() => {
-    Animated.timing(scaleAnim, {
-      toValue: 1,
-      duration: 100,
-      useNativeDriver: true,
-    }).start();
-  }, [scaleAnim]);
-
   const [signInVisible, setSignInVisible] = useState(false);
 
   if (!user) {
@@ -166,14 +162,16 @@ const ProfileScreen = () => {
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.guestCard}>
-            <View style={styles.guestAvatar} />
             <Text style={styles.guestTitle}>No profile to show</Text>
             <Text style={styles.guestDescription}>
               Sign in to view your account
             </Text>
             <Pressable
               style={styles.guestButton}
-              onPress={() => setSignInVisible(true)}
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                setSignInVisible(true);
+              }}
             >
               <Text style={styles.guestButtonText}>Continue</Text>
             </Pressable>
@@ -209,6 +207,7 @@ const ProfileScreen = () => {
         showsVerticalScrollIndicator={false}
       >
         {/* Profile Header Card with Gradient */}
+<<<<<<< Updated upstream
         <Pressable onPressIn={handlePressIn} onPressOut={handlePressOut}>
           <Animated.View style={[styles.headerCard, { transform: [{ scale: scaleAnim }] }]}>
             <View style={styles.headerCardGradient}>
@@ -222,23 +221,45 @@ const ProfileScreen = () => {
                 />
                 <Text style={styles.name}>{user?.name ?? "Your Profile"}</Text>
                 <Text style={styles.email}>{user?.email ?? ""}</Text>
+=======
+        <ScalePressable
+          style={styles.headerCard}
+          onPress={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            handleEditProfile();
+          }}
+        >
+          <View style={styles.headerCardGradient}>
+            <View style={styles.headerContent}>
+              <View style={styles.avatar}>
+                {user.avatar ? (
+                  <Image
+                    source={{ uri: `data:image/jpeg;base64,${user.avatar}` }}
+                    style={styles.avatarImage}
+                  />
+                ) : (
+                  <Text style={styles.avatarInitial}>{initial}</Text>
+                )}
+              </View>
+              <Text style={styles.name}>{user?.name ?? "Your Profile"}</Text>
+              <Text style={styles.email}>{user?.email ?? ""}</Text>
+>>>>>>> Stashed changes
 
-                {/* Stats Row */}
-                <View style={styles.statsPill}>
-                  <View style={styles.statItem}>
-                    <Text style={styles.statNumber}>{hostedCount}</Text>
-                    <Text style={styles.statLabel}>Hosted</Text>
-                  </View>
-                  <View style={styles.statDivider} />
-                  <View style={styles.statItem}>
-                    <Text style={styles.statNumber}>{joinedCount}</Text>
-                    <Text style={styles.statLabel}>Joined</Text>
-                  </View>
+              {/* Stats Row */}
+              <View style={styles.statsPill}>
+                <View style={styles.statItem}>
+                  <Text style={styles.statNumber}>{hostedCount}</Text>
+                  <Text style={styles.statLabel}>Hosted</Text>
+                </View>
+                <View style={styles.statDivider} />
+                <View style={styles.statItem}>
+                  <Text style={styles.statNumber}>{joinedCount}</Text>
+                  <Text style={styles.statLabel}>Joined</Text>
                 </View>
               </View>
             </View>
-          </Animated.View>
-        </Pressable>
+          </View>
+        </ScalePressable>
         {/* Menu Section */}
         <View style={styles.menuSection}>
           <MenuItem
@@ -266,12 +287,14 @@ const ProfileScreen = () => {
             label="Logout"
             onPress={handleSignOut}
             showChevron={false}
+            haptic="medium"
           />
           <MenuItem
             icon={<TrashIcon width={20} height={20} />}
             label="Delete"
             onPress={handleDelete}
             showChevron={false}
+            haptic="warning"
           />
         </View>
       </ScrollView>
@@ -368,12 +391,14 @@ const styles = StyleSheet.create({
     paddingTop: 12,
   },
   menuItem: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E6E6E6",
+  },
+  menuItemInner: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     paddingVertical: 17,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: "#E6E6E6",
   },
   menuItemLeft: {
     flexDirection: "row",
@@ -425,17 +450,20 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   guestButton: {
-    width: 173,
-    height: 48,
-    borderRadius: 52,
-    backgroundColor: colors.buttonBackground,
+    height: 52,
+    borderRadius: 26,
+    borderCurve: "continuous",
+    backgroundColor: "#000000",
+    paddingHorizontal: 32,
     alignItems: "center",
     justifyContent: "center",
   },
   guestButtonText: {
     fontSize: 16,
-    fontFamily: typography.fontFamilySemiBold,
+    fontFamily: typography.fontFamilyMedium,
     color: "#FFFFFF",
+    lineHeight: 20,
+    letterSpacing: -0.3,
   },
 });
 

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,10 +1,5 @@
 import {
   Alert,
-<<<<<<< Updated upstream
-  Animated,
-=======
-  Image,
->>>>>>> Stashed changes
   Pressable,
   ScrollView,
   StyleSheet,
@@ -207,21 +202,6 @@ const ProfileScreen = () => {
         showsVerticalScrollIndicator={false}
       >
         {/* Profile Header Card with Gradient */}
-<<<<<<< Updated upstream
-        <Pressable onPressIn={handlePressIn} onPressOut={handlePressOut}>
-          <Animated.View style={[styles.headerCard, { transform: [{ scale: scaleAnim }] }]}>
-            <View style={styles.headerCardGradient}>
-              <View style={styles.headerContent}>
-                <UserAvatar
-                  avatar={user.avatar}
-                  name={user.name}
-                  seed={user.id}
-                  size={68}
-                  style={styles.avatar}
-                />
-                <Text style={styles.name}>{user?.name ?? "Your Profile"}</Text>
-                <Text style={styles.email}>{user?.email ?? ""}</Text>
-=======
         <ScalePressable
           style={styles.headerCard}
           onPress={() => {
@@ -231,19 +211,15 @@ const ProfileScreen = () => {
         >
           <View style={styles.headerCardGradient}>
             <View style={styles.headerContent}>
-              <View style={styles.avatar}>
-                {user.avatar ? (
-                  <Image
-                    source={{ uri: `data:image/jpeg;base64,${user.avatar}` }}
-                    style={styles.avatarImage}
-                  />
-                ) : (
-                  <Text style={styles.avatarInitial}>{initial}</Text>
-                )}
-              </View>
+              <UserAvatar
+                avatar={user.avatar}
+                name={user.name}
+                seed={user.id}
+                size={68}
+                style={styles.avatar}
+              />
               <Text style={styles.name}>{user?.name ?? "Your Profile"}</Text>
               <Text style={styles.email}>{user?.email ?? ""}</Text>
->>>>>>> Stashed changes
 
               {/* Stats Row */}
               <View style={styles.statsPill}>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,4 @@
 export * from './colors';
 export * from './spacing';
 export * from './typography';
+export * from './springs';

--- a/src/theme/springs.ts
+++ b/src/theme/springs.ts
@@ -1,0 +1,16 @@
+// Named spring presets — single source of truth for all animation feel.
+// snappy:   overdamped — fast nav/dismiss transitions, no bounce
+// press:    slightly underdamped — scale press-release, page snap-back
+// bouncyUp: near-critical — sheet/badge slide-in, alive but no overshoot
+// elegant:  clearly underdamped — nav/sheet entries, tab icon bounce
+export const Springs = {
+  snappy:   { mass: 0.3, stiffness: 600, damping: 40 },
+  press:    { mass: 0.3, stiffness: 300, damping: 15 },
+  bouncyUp: { mass: 1, stiffness: 817, damping: 50 },
+  elegant:  { mass: 0.2, stiffness: 26.7, damping: 4.1 },
+} as const;
+
+// Shared timing durations — used where spring adds no value (opacity fades).
+export const durations = {
+  outgoingFade: 140,
+} as const;

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,12 +1,34 @@
 const AVATAR_COLORS = [
-  "#4CAF50",
-  "#9C27B0",
-  "#FF9800",
-  "#2196F3",
-  "#E91E63",
-  "#00BCD4",
-  "#8BC34A",
-  "#673AB7",
+  "#F43F5E", // Rose
+  "#E11D48", // Crimson
+  "#EC4899", // Pink
+  "#DB2777", // Deep Pink
+  "#D946EF", // Fuchsia
+  "#C026D3", // Magenta
+  "#A855F7", // Grape
+  "#9333EA", // Purple
+  "#8B5CF6", // Violet
+  "#7C3AED", // Deep Violet
+  "#6366F1", // Indigo
+  "#4F46E5", // Deep Indigo
+  "#3B82F6", // Blue
+  "#2563EB", // Deep Blue
+  "#0EA5E9", // Sky
+  "#0284C7", // Deep Sky
+  "#06B6D4", // Cyan
+  "#0891B2", // Deep Cyan
+  "#14B8A6", // Teal
+  "#0D9488", // Deep Teal
+  "#10B981", // Emerald
+  "#059669", // Deep Emerald
+  "#22C55E", // Green
+  "#16A34A", // Deep Green
+  "#F59E0B", // Amber
+  "#D97706", // Deep Amber
+  "#F97316", // Orange
+  "#EA580C", // Deep Orange
+  "#EF4444", // Red
+  "#DC2626", // Deep Red
 ] as const;
 
 const URI_PREFIXES = [


### PR DESCRIPTION
### Navigation and animation improvements


**Navigation & stack animations**                                                                                    
                                                                                                                   
- Replaced createNativeStackNavigator with createStackNavigator: Enables custom JS-driven card interpolators for full control over push/pop animations                                                                            
- Custom tab-like push animation: Incoming screen slides in from 30% right (matching tab feel); popping slides fully off to the right; underlying card fades and shifts left — consistent with iOS conventions                  
- Spring-based modal transitions: Sheet modals open with Springs.bouncyUp for a snappy, bouncy feel and close with Springs.snappy                                                                                              
- enableScreens(false): Prevents native screen management from removing screens before JS-driven fade animations finish                                                                                                           
                                                            
**Back navigation fix (Chat)**                                                                                       
                                                            
- navigate → push for ChatThread: In EventDetailsScreen and JoinRequestsScreen, navigating to chat now always pushes a new stack entry so pressing back returns exactly one screen
- Fixed double goBack() in ChatThreadScreen: Added isManuallyLeavingRef to prevent the useEffect (which watches activeConversationId) from calling goBack() a second time after the manual back press already called it          
   
**Swipe pager & filter tabs (HomeScreen + MyEventsScreen)**                                                          
                                                            
- Replaced PagerView with AnimatedPager: Custom Reanimated pager using GestureDetector + Pan for full control over swipe physics                                        
- Momentum-based swipe settle: Committed swipes use withSpring({ velocity: vx, overshootClamping: true }) — carries finger momentum naturally                                                                                
- Snap-back on cancelled swipes: Uses withTiming (180ms) for clean, predictable return when swipe threshold isn't met                                                                                                             
- Fixed double-animation bug: swipeCommittedRef prevents useLayoutEffect from re-animating after a swipe already animated the page change                                                                                         
- Smooth filter tracking on the UI thread: pageOffsetSV SharedValue written continuously during pan, read by SegmentedControl via useDerivedValue — zero JS bridge latency                                                    
- Filter snaps instantly on tap: Direct assignment pageOffsetSV.value = to on tap (no animation); swipe tracking uses the continuous shared value                                                                                 
                                                            
**SegmentedControl redesign**                                                                                        
                                                            
- Fully Reanimated: Tabs animate with interpolateColor between inactive (transparent background, #494949 label, #E6E6E6 border) and active (solid black background, white label)
- Count badge: Optional count shown alongside label, fades from gray to white when selected                      
- Swipe-driven animation: When pageOffset prop is passed, tab progress is derived entirely on the UI thread; falls back to spring animation for tap-only usage                                                                
- Haptics on tab press                                                                                           
                                                                                                                   
**Haptics across the app**                                    
                                                                                                                   
- Added throughout EventDetailsScreen: button presses, join/leave/delete actions (Light, Medium, Success, Warning, Error feedback types)
- Added to ChatThreadScreen: back button, message send                                                           
- Added to CreateEventScreen: all field pickers, confirmations, submit                                           
- Added to SegmentedControl tab presses                                                                          
                                                                                                                   
**Create event validation**                                                                                          
                                                                                                                   
- All three fields now required: Event name, description, and location must all be filled — shows "All fields are required" if any are missing
- Removed silent "New event" fallback: Previously an event could be submitted with an empty name field           
                                                                                                                   
                                                            
**Cover picker**                                                                                                     
   
- Change the selected cover border active
                                                            
**Empty state polish**                                                                                               
   
- Removed all forced \n line breaks from empty state descriptions across MyEventsScreen, HomeScreen, and        MessagesScreen                                            
- Added maxWidth: 280 to description text so it wraps naturally at balanced line lengths                         
                                                                                                                   
**Unread dot position fix**                                                                                          
                                                                                                                   
- Chat tab icon unread dot repositioned from near-center (top: 5, right: 15) to top-right corner (top: 0, right: 2)                                                        
                                                                                                                   
**After**
<img width="585" height="1266" alt="IMG_9065" src="https://github.com/user-attachments/assets/f1ab1970-3357-45a9-986e-664a970fd015" />
<img width="585" height="1266" alt="IMG_9066" src="https://github.com/user-attachments/assets/3a17f587-b1c2-4354-bd52-dda0a7f1d0c3" />
<img width="585" height="1266" alt="IMG_9067" src="https://github.com/user-attachments/assets/ed6b2a8f-3f10-4427-b12a-2deed0261966" />
<img width="585" height="1266" alt="IMG_9068" src="https://github.com/user-attachments/assets/8f1cdbb0-d368-413a-bf86-b4248e6e9ef4" />

