### PR TITLE
Fix/create event keyboard

### DIFF
--- a/assets/create-event/check-selected-cover.svg
+++ b/assets/create-event/check-selected-cover.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.19995 7.70013L5.49995 13.2001L13.2 1.20013" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/CoverPickerModal.tsx
+++ b/src/components/CoverPickerModal.tsx
@@ -7,7 +7,7 @@ import { BlurView } from "expo-blur";
 
 import { COVER_OPTIONS, CoverKey } from "@constants/covers";
 import { spacing } from "@theme/index";
-import JoinedIcon from "@assets/event/joined.svg";
+import CheckSelectedCoverIcon from "@assets/create-event/check-selected-cover.svg";
 import BottomSheetModal from "./BottomSheetModal";
 import styles from "./CoverPickerModal.styles";
 
@@ -56,7 +56,7 @@ const CoverPickerModal: React.FC<CoverPickerModalProps> = ({
                                     </View>
                                     {isSelected && (
                                         <BlurView intensity={60} tint="dark" style={styles.checkBadge}>
-                                            <JoinedIcon width={14} height={14} />
+                                            <CheckSelectedCoverIcon width={14} height={14} />
                                         </BlurView>
                                     )}
                                 </Pressable>

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     Image,
+    Keyboard,
     Platform,
     Pressable,
     Text,
@@ -251,18 +252,21 @@ const CreateEventScreen = () => {
 
     // Open modal handlers - set temp to current value
     const openAgePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempAgeRange(ageRange);
         setAgePickerVisible(true);
     }, [ageRange]);
 
     const openGenderPicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGender(gender);
         setGenderPickerVisible(true);
     }, [gender]);
 
     const openGroupTypePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGroupType(groupType);
         setGroupTypePickerVisible(true);
@@ -586,6 +590,7 @@ const CreateEventScreen = () => {
             <Pressable
                 style={styles.coverCard}
                 onPress={() => {
+                    Keyboard.dismiss();
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     setCoverPickerVisible(true);
                 }}
@@ -672,6 +677,7 @@ const CreateEventScreen = () => {
                     <Pressable
                         style={[styles.fieldRow, styles.dateRow]}
                         onPress={() => {
+                            Keyboard.dismiss();
                             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                             setDateTimePickerVisible(true);
                         }}


### PR DESCRIPTION
**Fixed: Keyboard issue in Create Event page
Changed: Check icon on selected cover in Create Event page**

---

**Keyboard dismiss on selector open in CreateEventScreen**                                                           
Added Keyboard.dismiss() before opening each selector (group type, gender, age, date/time, cover picker) so that any active text input loses focus before the selector modal mounts. This prevents React Native from restoring focus to the previously active input after the selector closes, which was causing text fields to re-highlight unexpectedly.                                                                                                    
                                                                                                                   
**Replace joined icon with custom check icon in CoverPickerModal**                                                   
Swapped the selected-cover checkmark from the generic joined.svg to the purpose-built check-selected-cover.svg from the create-event assets folder.