### PR TITLE
Fix/filter animation

### DIFF
--- a/assets/create-event/check-selected-cover.svg
+++ b/assets/create-event/check-selected-cover.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.19995 7.70013L5.49995 13.2001L13.2 1.20013" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/AnimatedPager.tsx
+++ b/src/components/AnimatedPager.tsx
@@ -139,6 +139,7 @@ const AnimatedPager = ({
       if (committed) {
         isAnimating.value = true;
         runOnJS(triggerHaptic)();
+        runOnJS(notifyPageChange)(to);
         selectedIndexSV.value = to;
 
         if (pageOffsetSV) {
@@ -148,9 +149,6 @@ const AnimatedPager = ({
         slides[from].value = withSpring(toIsNext ? -w : w, { ...COMMIT_SPRING, velocity: vx });
         slides[to].value = withSpring(0, { ...COMMIT_SPRING, velocity: vx }, (finished) => {
           isAnimating.value = false;
-          if (finished) {
-            runOnJS(notifyPageChange)(to);
-          }
         });
       } else {
         // Not committed — snap back with timing

--- a/src/components/CoverPickerModal.tsx
+++ b/src/components/CoverPickerModal.tsx
@@ -7,7 +7,7 @@ import { BlurView } from "expo-blur";
 
 import { COVER_OPTIONS, CoverKey } from "@constants/covers";
 import { spacing } from "@theme/index";
-import JoinedIcon from "@assets/event/joined.svg";
+import CheckSelectedCoverIcon from "@assets/create-event/check-selected-cover.svg";
 import BottomSheetModal from "./BottomSheetModal";
 import styles from "./CoverPickerModal.styles";
 
@@ -56,7 +56,7 @@ const CoverPickerModal: React.FC<CoverPickerModalProps> = ({
                                     </View>
                                     {isSelected && (
                                         <BlurView intensity={60} tint="dark" style={styles.checkBadge}>
-                                            <JoinedIcon width={14} height={14} />
+                                            <CheckSelectedCoverIcon width={14} height={14} />
                                         </BlurView>
                                     )}
                                 </Pressable>

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -5,7 +5,6 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
   interpolateColor,
-  useDerivedValue,
   type SharedValue,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
@@ -23,35 +22,24 @@ interface SegmentedControlProps {
   options: SegmentedOption[];
   value: string;
   onChange: (value: string) => void;
-  /** Pass the pageOffsetSV from AnimatedPager for smooth swipe-driven tab transitions. */
-  pageOffset?: SharedValue<number>;
 }
 
 type TabProps = {
   option: SegmentedOption;
-  tabIndex: number;
   localProgress: SharedValue<number>;
-  pageOffset?: SharedValue<number>;
   onPress: () => void;
 };
 
-const SegmentedTab = ({ option, tabIndex, localProgress, pageOffset, onPress }: TabProps) => {
-  // Derives 0→1 progress on the UI thread: 1 when selected, 0 when not
-  const effectiveProgress = useDerivedValue(() =>
-    pageOffset
-      ? Math.max(0, 1 - Math.abs(pageOffset.value - tabIndex))
-      : localProgress.value
-  );
-
+const SegmentedTab = ({ option, localProgress, onPress }: TabProps) => {
   const tabStyle = useAnimatedStyle(() => ({
-    backgroundColor: interpolateColor(effectiveProgress.value, [0, 1], ['transparent', '#000000']),
-    borderColor: interpolateColor(effectiveProgress.value, [0, 1], ['#E6E6E6', 'transparent']),
+    backgroundColor: interpolateColor(localProgress.value, [0, 1], ['transparent', '#000000']),
+    borderColor: interpolateColor(localProgress.value, [0, 1], ['#E6E6E6', 'transparent']),
   }));
   const labelStyle = useAnimatedStyle(() => ({
-    color: interpolateColor(effectiveProgress.value, [0, 1], ['#494949', '#FFFFFF']),
+    color: interpolateColor(localProgress.value, [0, 1], ['#494949', '#FFFFFF']),
   }));
   const countStyle = useAnimatedStyle(() => ({
-    color: interpolateColor(effectiveProgress.value, [0, 1], ['#808080', 'rgba(255,255,255,0.7)']),
+    color: interpolateColor(localProgress.value, [0, 1], ['#808080', 'rgba(255,255,255,0.7)']),
   }));
 
   return (
@@ -71,7 +59,7 @@ const SegmentedTab = ({ option, tabIndex, localProgress, pageOffset, onPress }: 
 };
 
 // Up to 4 tabs — shared values must be created unconditionally at top level.
-const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedControlProps) => {
+const SegmentedControl = ({ options, value, onChange }: SegmentedControlProps) => {
   const selectedIndex = options.findIndex(o => o.value === value);
   const prevIndex = useRef(selectedIndex);
 
@@ -81,7 +69,6 @@ const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedCon
   const sv3 = useSharedValue(selectedIndex === 3 ? 1 : 0);
   const allSvs = [sv0, sv1, sv2, sv3];
 
-  // Spring-based fallback for programmatic tab changes (tap) when pageOffset not provided
   useEffect(() => {
     const prev = prevIndex.current;
     if (prev === selectedIndex) return;
@@ -96,9 +83,7 @@ const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedCon
         <SegmentedTab
           key={option.value}
           option={option}
-          tabIndex={i}
           localProgress={allSvs[i]}
-          pageOffset={pageOffset}
           onPress={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
             onChange(option.value);

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     Image,
+    Keyboard,
     Platform,
     Pressable,
     Text,
@@ -251,18 +252,21 @@ const CreateEventScreen = () => {
 
     // Open modal handlers - set temp to current value
     const openAgePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempAgeRange(ageRange);
         setAgePickerVisible(true);
     }, [ageRange]);
 
     const openGenderPicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGender(gender);
         setGenderPickerVisible(true);
     }, [gender]);
 
     const openGroupTypePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGroupType(groupType);
         setGroupTypePickerVisible(true);
@@ -586,6 +590,7 @@ const CreateEventScreen = () => {
             <Pressable
                 style={styles.coverCard}
                 onPress={() => {
+                    Keyboard.dismiss();
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     setCoverPickerVisible(true);
                 }}
@@ -672,6 +677,7 @@ const CreateEventScreen = () => {
                     <Pressable
                         style={[styles.fieldRow, styles.dateRow]}
                         onPress={() => {
+                            Keyboard.dismiss();
                             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                             setDateTimePickerVisible(true);
                         }}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -323,7 +323,6 @@ const HomeScreen = () => {
                 const index = sortOptions.findIndex((o) => o.value === value);
                 setSelectedPage(index);
               }}
-              pageOffset={pageOffset}
             />
           </View>
         </View>

--- a/src/screens/MyEventsScreen.tsx
+++ b/src/screens/MyEventsScreen.tsx
@@ -303,7 +303,6 @@ const MyEventsScreen = () => {
                 const index = filterOptions.findIndex((o) => o.value === value);
                 setSelectedPage(index);
               }}
-              pageOffset={pageOffset}
             />
           </View>
         </View>


### PR DESCRIPTION
**Segmented control (i.e. Filter on top in Discovery/MyEvent): snap pill on swipe, instead of tracking gesture**                                         
                                                                                                                   
Previously the tab pill was driven by pageOffset in real-time during swipes, causing both tabs to pass through a simultaneous grey/intermediate state at the swipe midpoint. The pill now ignores swipe progress entirely and springs to the new tab the moment the swipe commits — matching the behaviour of iOS and Spotify's segmented controls. To make this feel responsive (not lagging), notifyPageChange in AnimatedPager was moved from the spring completion callback to the commit point, so the pill spring and page spring run concurrently