### PR TITLE
Change/account card bg

### DIFF
--- a/assets/create-event/check-selected-cover.svg
+++ b/assets/create-event/check-selected-cover.svg
@@ -1,0 +1,3 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.19995 7.70013L5.49995 13.2001L13.2 1.20013" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/AnimatedPager.tsx
+++ b/src/components/AnimatedPager.tsx
@@ -139,6 +139,7 @@ const AnimatedPager = ({
       if (committed) {
         isAnimating.value = true;
         runOnJS(triggerHaptic)();
+        runOnJS(notifyPageChange)(to);
         selectedIndexSV.value = to;
 
         if (pageOffsetSV) {
@@ -148,9 +149,6 @@ const AnimatedPager = ({
         slides[from].value = withSpring(toIsNext ? -w : w, { ...COMMIT_SPRING, velocity: vx });
         slides[to].value = withSpring(0, { ...COMMIT_SPRING, velocity: vx }, (finished) => {
           isAnimating.value = false;
-          if (finished) {
-            runOnJS(notifyPageChange)(to);
-          }
         });
       } else {
         // Not committed — snap back with timing

--- a/src/components/CoverPickerModal.tsx
+++ b/src/components/CoverPickerModal.tsx
@@ -7,7 +7,7 @@ import { BlurView } from "expo-blur";
 
 import { COVER_OPTIONS, CoverKey } from "@constants/covers";
 import { spacing } from "@theme/index";
-import JoinedIcon from "@assets/event/joined.svg";
+import CheckSelectedCoverIcon from "@assets/create-event/check-selected-cover.svg";
 import BottomSheetModal from "./BottomSheetModal";
 import styles from "./CoverPickerModal.styles";
 
@@ -56,7 +56,7 @@ const CoverPickerModal: React.FC<CoverPickerModalProps> = ({
                                     </View>
                                     {isSelected && (
                                         <BlurView intensity={60} tint="dark" style={styles.checkBadge}>
-                                            <JoinedIcon width={14} height={14} />
+                                            <CheckSelectedCoverIcon width={14} height={14} />
                                         </BlurView>
                                     )}
                                 </Pressable>

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -5,7 +5,6 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
   interpolateColor,
-  useDerivedValue,
   type SharedValue,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
@@ -23,35 +22,24 @@ interface SegmentedControlProps {
   options: SegmentedOption[];
   value: string;
   onChange: (value: string) => void;
-  /** Pass the pageOffsetSV from AnimatedPager for smooth swipe-driven tab transitions. */
-  pageOffset?: SharedValue<number>;
 }
 
 type TabProps = {
   option: SegmentedOption;
-  tabIndex: number;
   localProgress: SharedValue<number>;
-  pageOffset?: SharedValue<number>;
   onPress: () => void;
 };
 
-const SegmentedTab = ({ option, tabIndex, localProgress, pageOffset, onPress }: TabProps) => {
-  // Derives 0→1 progress on the UI thread: 1 when selected, 0 when not
-  const effectiveProgress = useDerivedValue(() =>
-    pageOffset
-      ? Math.max(0, 1 - Math.abs(pageOffset.value - tabIndex))
-      : localProgress.value
-  );
-
+const SegmentedTab = ({ option, localProgress, onPress }: TabProps) => {
   const tabStyle = useAnimatedStyle(() => ({
-    backgroundColor: interpolateColor(effectiveProgress.value, [0, 1], ['transparent', '#000000']),
-    borderColor: interpolateColor(effectiveProgress.value, [0, 1], ['#E6E6E6', 'transparent']),
+    backgroundColor: interpolateColor(localProgress.value, [0, 1], ['transparent', '#000000']),
+    borderColor: interpolateColor(localProgress.value, [0, 1], ['#E6E6E6', 'transparent']),
   }));
   const labelStyle = useAnimatedStyle(() => ({
-    color: interpolateColor(effectiveProgress.value, [0, 1], ['#494949', '#FFFFFF']),
+    color: interpolateColor(localProgress.value, [0, 1], ['#494949', '#FFFFFF']),
   }));
   const countStyle = useAnimatedStyle(() => ({
-    color: interpolateColor(effectiveProgress.value, [0, 1], ['#808080', 'rgba(255,255,255,0.7)']),
+    color: interpolateColor(localProgress.value, [0, 1], ['#808080', 'rgba(255,255,255,0.7)']),
   }));
 
   return (
@@ -71,7 +59,7 @@ const SegmentedTab = ({ option, tabIndex, localProgress, pageOffset, onPress }: 
 };
 
 // Up to 4 tabs — shared values must be created unconditionally at top level.
-const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedControlProps) => {
+const SegmentedControl = ({ options, value, onChange }: SegmentedControlProps) => {
   const selectedIndex = options.findIndex(o => o.value === value);
   const prevIndex = useRef(selectedIndex);
 
@@ -81,7 +69,6 @@ const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedCon
   const sv3 = useSharedValue(selectedIndex === 3 ? 1 : 0);
   const allSvs = [sv0, sv1, sv2, sv3];
 
-  // Spring-based fallback for programmatic tab changes (tap) when pageOffset not provided
   useEffect(() => {
     const prev = prevIndex.current;
     if (prev === selectedIndex) return;
@@ -96,9 +83,7 @@ const SegmentedControl = ({ options, value, onChange, pageOffset }: SegmentedCon
         <SegmentedTab
           key={option.value}
           option={option}
-          tabIndex={i}
           localProgress={allSvs[i]}
-          pageOffset={pageOffset}
           onPress={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
             onChange(option.value);

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
 import {
-  Platform,
   StyleProp,
   StyleSheet,
   Text,
@@ -42,7 +41,6 @@ const UserAvatar = ({
   const initials = getAvatarInitials(name, maxInitials);
   const backgroundColor = getAvatarColor(seed, name);
   const fontSize = Math.max(12, Math.round(size * 0.38));
-  const lineHeight = Math.max(fontSize, Math.round(fontSize * 1.1));
 
   return (
     <View
@@ -64,7 +62,7 @@ const UserAvatar = ({
       ) : (
         <View style={styles.initialsFrame}>
           <Text
-            style={[styles.initials, { fontSize, lineHeight }, textStyle]}
+            style={[styles.initials, { fontSize, lineHeight: size }, textStyle]}
             numberOfLines={1}
           >
             {initials}
@@ -98,11 +96,6 @@ const styles = StyleSheet.create({
     textAlign: "center",
     includeFontPadding: false,
     textAlignVertical: "center",
-    transform: [
-      {
-        translateY: Platform.OS === "android" ? -0.5 : 0,
-      },
-    ],
   },
 });
 

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     Image,
+    Keyboard,
     Platform,
     Pressable,
     Text,
@@ -251,18 +252,21 @@ const CreateEventScreen = () => {
 
     // Open modal handlers - set temp to current value
     const openAgePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempAgeRange(ageRange);
         setAgePickerVisible(true);
     }, [ageRange]);
 
     const openGenderPicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGender(gender);
         setGenderPickerVisible(true);
     }, [gender]);
 
     const openGroupTypePicker = useCallback(() => {
+        Keyboard.dismiss();
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         setTempGroupType(groupType);
         setGroupTypePickerVisible(true);
@@ -586,6 +590,7 @@ const CreateEventScreen = () => {
             <Pressable
                 style={styles.coverCard}
                 onPress={() => {
+                    Keyboard.dismiss();
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     setCoverPickerVisible(true);
                 }}
@@ -672,6 +677,7 @@ const CreateEventScreen = () => {
                     <Pressable
                         style={[styles.fieldRow, styles.dateRow]}
                         onPress={() => {
+                            Keyboard.dismiss();
                             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                             setDateTimePickerVisible(true);
                         }}

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -1343,7 +1343,7 @@ const EventDetailsScreen = () => {
                       ]}
                       testID={`going-avatar-${index}`}
                     >
-                      {renderAvatar(participant, 24)}
+                      {renderAvatar(participant, 28)}
                     </View>
                   ))}
                 </View>
@@ -2101,6 +2101,8 @@ const styles = StyleSheet.create({
   },
   goingAvatarItem: {
     borderRadius: 999,
+    borderWidth: 1.5,
+    borderColor: "#FFFFFF",
   },
   goingAvatarOverlap: {
     marginLeft: -9,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -323,7 +323,6 @@ const HomeScreen = () => {
                 const index = sortOptions.findIndex((o) => o.value === value);
                 setSelectedPage(index);
               }}
-              pageOffset={pageOffset}
             />
           </View>
         </View>

--- a/src/screens/MyEventsScreen.tsx
+++ b/src/screens/MyEventsScreen.tsx
@@ -303,7 +303,6 @@ const MyEventsScreen = () => {
                 const index = filterOptions.findIndex((o) => o.value === value);
                 setSelectedPage(index);
               }}
-              pageOffset={pageOffset}
             />
           </View>
         </View>

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import ScalePressable from "@components/ScalePressable";
 
 import { useCallback, useMemo, useState } from "react";
@@ -189,7 +190,13 @@ const ProfileScreen = () => {
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          <View style={styles.guestCard}>
+          <LinearGradient
+            colors={['#E2E5FB', '#E2E5FB', '#B8DCFB']}
+            locations={[0, 0.42, 1]}
+            start={{ x: 0.25, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.guestCard}
+          >
             <Text style={styles.guestTitle}>No profile to show</Text>
             <Text style={styles.guestDescription}>
               Sign in to view your account
@@ -203,7 +210,7 @@ const ProfileScreen = () => {
             >
               <Text style={styles.guestButtonText}>Continue</Text>
             </Pressable>
-          </View>
+          </LinearGradient>
           <View style={styles.menuSection}>
             <MenuItem
               icon={<PrivacyPolicyIcon width={20} height={20} color="#000000" />}
@@ -256,32 +263,38 @@ const ProfileScreen = () => {
             handleEditProfile();
           }}
         >
-          <View style={styles.headerCardGradient}>
+          <LinearGradient
+            colors={['#E2E5FB', '#E2E5FB', '#B8DCFB']}
+            locations={[0, 0.42, 1]}
+            start={{ x: 0.25, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.headerCardGradient}
+          >
             <View style={styles.headerContent}>
               <UserAvatar
                 avatar={user.avatar}
                 name={user.name}
                 seed={user.id}
-                size={68}
+                size={64}
                 style={styles.avatar}
               />
               <Text style={styles.name}>{user?.name ?? "Your Profile"}</Text>
               <Text style={styles.email}>{user?.email ?? ""}</Text>
 
               {/* Stats Row */}
-              <View style={styles.statsPill}>
-                <View style={styles.statItem}>
+              <View style={styles.statsRow}>
+                <Text style={styles.statText}>
                   <Text style={styles.statNumber}>{hostedCount}</Text>
-                  <Text style={styles.statLabel}>Hosted</Text>
-                </View>
-                <View style={styles.statDivider} />
-                <View style={styles.statItem}>
+                  <Text style={styles.statLabel}> Hosted</Text>
+                </Text>
+                <View style={styles.statDot} />
+                <Text style={styles.statText}>
                   <Text style={styles.statNumber}>{joinedCount}</Text>
-                  <Text style={styles.statLabel}>Joined</Text>
-                </View>
+                  <Text style={styles.statLabel}> Joined</Text>
+                </Text>
               </View>
             </View>
-          </View>
+          </LinearGradient>
         </ScalePressable>
         {/* Menu Section */}
         <View style={styles.menuSection}>
@@ -364,65 +377,64 @@ const styles = StyleSheet.create({
     borderCurve: "continuous",
     overflow: "hidden",
   },
-  headerCardGradient: {
-    backgroundColor: "#1B50E3",
-  },
+  headerCardGradient: {},
   headerContent: {
     alignItems: "center",
-    paddingTop: 20,
-    paddingBottom: 20,
+    paddingTop: 24,
+    paddingBottom: 24,
     paddingHorizontal: spacing.md,
   },
   avatar: {
-    width: 68,
-    height: 68,
-    borderRadius: 34,
-    backgroundColor: "rgba(255,255,255,0.2)",
+    width: 64,
+    height: 64,
+    borderRadius: 32,
     alignItems: "center",
     justifyContent: "center",
     marginBottom: spacing.md,
     overflow: "hidden",
     borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.2)",
+    borderColor: "rgba(0,0,0,0.1)",
   },
   name: {
     fontSize: 20,
-    color: "#FFFFFF",
+    color: "#000000",
     fontFamily: typography.fontFamilyMedium,
     letterSpacing: -0.5,
     marginBottom: 4,
   },
   email: {
     fontSize: 14,
-    color: "rgba(255, 255, 255, 0.5)",
+    color: "rgba(0,0,0,0.5)",
     fontFamily: typography.fontFamilyRegular,
     letterSpacing: -0.5,
     marginBottom: 24,
   },
-  statsPill: {
+  statsRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: spacing.xl,
+    gap: 8,
   },
-  statDivider: {
-    width: 1,
-    height: 36,
-    backgroundColor: "rgba(255,255,255,0.25)",
+  statDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 1.5,
+    backgroundColor: "rgba(0,0,0,0.3)",
   },
-  statItem: {
-    alignItems: "center",
-    gap: 2,
+  statText: {
+    fontSize: 16,
+    letterSpacing: -0.3,
   },
   statNumber: {
-    fontSize: 18,
-    color: "#FFFFFF",
+    fontSize: 16,
+    color: "#000000",
     fontFamily: typography.fontFamilyMedium,
-    letterSpacing: -0.5,
+    letterSpacing: -0.3,
   },
   statLabel: {
-    fontSize: 14,
-    color: "rgba(255,255,255,0.5)",
+    fontSize: 16,
+    color: "rgba(0,0,0,0.5)",
     fontFamily: typography.fontFamilyRegular,
+    letterSpacing: -0.3,
   },
   menuSection: {
     paddingTop: 12,
@@ -455,8 +467,9 @@ const styles = StyleSheet.create({
     color: "#000000",
   },
   guestCard: {
-    backgroundColor: "#F5F5F5",
     borderRadius: 20,
+    borderCurve: "continuous",
+    overflow: "hidden",
     alignItems: "center",
     paddingVertical: 24,
     paddingHorizontal: spacing.md,

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,34 +1,23 @@
 const AVATAR_COLORS = [
-  "#F43F5E", // Rose
-  "#E11D48", // Crimson
-  "#EC4899", // Pink
-  "#DB2777", // Deep Pink
-  "#D946EF", // Fuchsia
-  "#C026D3", // Magenta
-  "#A855F7", // Grape
-  "#9333EA", // Purple
-  "#8B5CF6", // Violet
-  "#7C3AED", // Deep Violet
-  "#6366F1", // Indigo
-  "#4F46E5", // Deep Indigo
-  "#3B82F6", // Blue
-  "#2563EB", // Deep Blue
-  "#0EA5E9", // Sky
-  "#0284C7", // Deep Sky
-  "#06B6D4", // Cyan
-  "#0891B2", // Deep Cyan
-  "#14B8A6", // Teal
-  "#0D9488", // Deep Teal
-  "#10B981", // Emerald
-  "#059669", // Deep Emerald
-  "#22C55E", // Green
-  "#16A34A", // Deep Green
-  "#F59E0B", // Amber
-  "#D97706", // Deep Amber
-  "#F97316", // Orange
-  "#EA580C", // Deep Orange
-  "#EF4444", // Red
-  "#DC2626", // Deep Red
+  "#4BBBA5",
+  "#F07A38",
+  "#7CBAD4",
+  "#F4A0B5",
+  "#9B72CF",
+  "#6B82B0",
+  "#E85D4A",
+  "#E8A64A",
+  "#6DC8A0",
+  "#B99FDB",
+  "#E05252",
+  "#5BBCE4",
+  "#8DC44A",
+  "#F08030",
+  "#E87090",
+  "#48C4C4",
+  "#F0BC2C",
+  "#9E78C4",
+  "#F07878",
 ] as const;
 
 const URI_PREFIXES = [


### PR DESCRIPTION
### Account page: profile card redesign                                                                              
                                                                                                                   
- Replaced the solid blue background on the profile header card with a soft radial-style gradient (#E2E5FB → #B8DCFB) using expo-linear-gradient. The same gradient is applied to the logged-out guest card. All text updated from white to black  -name, email, stat numbers, and stat labels use black with matching opacity for secondary text.                                                                                                            
                                                                                                                   
- The stats display was redesigned from a vertical two-column pill layout (with a divider) to a single inline row: "1 Hosted · 0 Joined", with a 3×3 circular dot separator. Number weight changed to medium, labels remain regular at 50% opacity.                                                                                                  
                                                            
- Avatar size reduced from 68 → 64px. Card padding increased to 24px top/bottom for more breathing room. Guest card corners use borderCurve: "continuous" to match iOS smooth corner style.

**After**
<img width="585" height="1266" alt="IMG_9151" src="https://github.com/user-attachments/assets/58d874da-7279-4d14-ab6f-0e735aa80c8f" />
<img width="585" height="1266" alt="IMG_9152" src="https://github.com/user-attachments/assets/9dace9cc-4c4b-438b-a302-6e9ee8eaccf4" />
