### PR TITLE
Fixed: Sheet top gap and navigation transition cleanup

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -7,6 +7,7 @@ import {
     StyleSheet,
     Text,
     View,
+    useWindowDimensions,
 } from "react-native";
 import Animated, {
     useSharedValue,
@@ -32,7 +33,6 @@ export type BottomSheetModalProps = {
     title?: string;
 };
 
-const SLIDE_DISTANCE = 500;
 const BASE_PADDING_BOTTOM = 8;
 
 // Bezier approximation of iOS UIViewAnimationCurveKeyboard
@@ -40,13 +40,15 @@ const IOS_KEYBOARD_EASING = Easing.bezier(0.36, 0.66, 0.04, 1);
 
 const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModalProps) => {
     const { bottom: safeBottom } = useSafeAreaInsets();
+    const { height: screenHeight } = useWindowDimensions();
     const basePadding = BASE_PADDING_BOTTOM + safeBottom;
 
-    const slideAnim = useSharedValue(SLIDE_DISTANCE);
+    const slideAnim = useSharedValue(screenHeight);
     const backdropAnim = useSharedValue(0);
     const keyboardPaddingAnim = useSharedValue(basePadding);
     const [modalVisible, setModalVisible] = useState(false);
     const hasBeenVisible = useRef(false);
+    const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const sheetStyle = useAnimatedStyle(() => ({
         transform: [{ translateY: slideAnim.value }],
@@ -59,25 +61,28 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
     }));
 
     const startOpenAnimation = useCallback(() => {
-        slideAnim.value = SLIDE_DISTANCE;
+        slideAnim.value = screenHeight;
         backdropAnim.value = 0;
         keyboardPaddingAnim.value = basePadding;
         slideAnim.value = withSpring(0, Springs.bouncyUp);
         backdropAnim.value = withTiming(1, { duration: 100, easing: Easing.out(Easing.cubic) });
-    }, [basePadding]);
+    }, [basePadding, screenHeight]);
 
     useEffect(() => {
         if (visible) {
+            if (dismissTimerRef.current) {
+                clearTimeout(dismissTimerRef.current);
+                dismissTimerRef.current = null;
+            }
             hasBeenVisible.current = true;
             setModalVisible(true);
             // Animation starts in onShow, after the modal content is rendered
         } else if (hasBeenVisible.current) {
-            slideAnim.value = withSpring(SLIDE_DISTANCE, Springs.snappy, (finished) => {
-                if (finished) runOnJS(setModalVisible)(false);
-            });
+            slideAnim.value = withSpring(screenHeight, Springs.elegant);
             backdropAnim.value = withTiming(0, { duration: 120, easing: Easing.in(Easing.ease) });
+            dismissTimerRef.current = setTimeout(() => setModalVisible(false), 400);
         }
-    }, [visible]);
+    }, [visible, screenHeight]);
 
     useEffect(() => {
         const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -57,39 +57,19 @@ const Stack = createStackNavigator<RootStackParamList>();
 // ─── Stack screen animation ───────────────────────────────────────────────────
 // Push (open):  incoming slides from 30% right — matches tab animation
 // Pop  (close): card slides fully off to the right — standard iOS back feel
-const tabLikeInterpolator = ({ current, next, layouts, closing }: StackCardInterpolationProps) => {
-  const { width } = layouts.screen;
+const slideFromRightInterpolator = ({ current, layouts }: StackCardInterpolationProps) => ({
+  cardStyle: {
+    transform: [{
+      translateX: current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [layouts.screen.width, 0],
+        extrapolate: 'clamp',
+      }),
+    }],
+  },
+});
 
-  if (next) {
-    // This card is below an incoming card: slide left + fade out
-    return {
-      cardStyle: {
-        transform: [{
-          translateX: next.progress.interpolate({ inputRange: [0, 1], outputRange: [0, -width * 0.2], extrapolate: 'clamp' }),
-        }],
-        opacity: next.progress.interpolate({ inputRange: [0, 1], outputRange: [1, 0], extrapolate: 'clamp' }),
-      },
-    };
-  }
-
-  // Top card: open from 30% right, close to full width right
-  const translateXOpen  = current.progress.interpolate({ inputRange: [0, 1], outputRange: [width * 0.3, 0], extrapolate: 'clamp' });
-  const translateXClose = current.progress.interpolate({ inputRange: [0, 1], outputRange: [width, 0],       extrapolate: 'clamp' });
-
-  // Blend: when closing=0 use open translation, when closing=1 use close translation
-  const translateX = Animated.add(
-    translateXOpen,
-    Animated.multiply(closing, Animated.subtract(translateXClose, translateXOpen)),
-  );
-
-  return {
-    cardStyle: {
-      transform: [{ translateX }],
-    },
-  };
-};
-
-const tabLikeTransitionSpec = {
+const slideFromRightTransitionSpec = {
   open:  { animation: 'spring' as const, config: Springs.snappy },
   close: { animation: 'spring' as const, config: Springs.snappy },
 };
@@ -136,7 +116,7 @@ const sheetModalInterpolator = ({ current, layouts }: StackCardInterpolationProp
 
 const sheetModalTransitionSpec = {
   open:  { animation: 'spring' as const, config: Springs.bouncyUp },
-  close: { animation: 'spring' as const, config: Springs.snappy },
+  close: { animation: 'spring' as const, config: Springs.elegant },
 };
 
 // How far the sheet background extends below the screen.
@@ -650,7 +630,6 @@ const AppNavigator = () => {
           component={GoogleSignIn}
           options={{
             presentation: "transparentModal",
-            cardStyleInterpolator: CardStyleInterpolators.forFadeFromCenter,
           }}
         />
         <Stack.Screen
@@ -665,16 +644,16 @@ const AppNavigator = () => {
           name="EventDetails"
           component={EventDetailsScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
           name="JoinRequests"
           component={JoinRequestsScreen}
           options={{
-            cardStyleInterpolator: slideFromBottomInterpolator,
-            transitionSpec: slideFromBottomTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
@@ -713,40 +692,40 @@ const AppNavigator = () => {
           name="EditProfile"
           component={EditProfileScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
           name="PastEvents"
           component={PastEventsScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
           name="PrivacyPolicy"
           component={PrivacyPolicyScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
           name="Help"
           component={HelpScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
         <Stack.Screen
           name="ChatThread"
           component={ChatThreadScreen}
           options={{
-            cardStyleInterpolator: tabLikeInterpolator,
-            transitionSpec: tabLikeTransitionSpec,
+            cardStyleInterpolator: slideFromRightInterpolator,
+            transitionSpec: slideFromRightTransitionSpec,
           }}
         />
       </Stack.Navigator>

--- a/src/screens/PendingRequestsScreen.tsx
+++ b/src/screens/PendingRequestsScreen.tsx
@@ -105,7 +105,7 @@ const PendingRequestsScreen = () => {
   };
 
   return (
-    <ScreenContainer edges={["top", "bottom"]}>
+    <ScreenContainer edges={["bottom"]}>
       <View style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.headerTitle}>


### PR DESCRIPTION
### Fixed: Sheet top gap and navigation transition cleanup

**AppNavigator.tsx**                                                                                                                 
- tabLikeInterpolator → renamed to slideFromRightInterpolator and simplified (full-width slide from right, outgoing screen stays still)                                                                                                                            
- JoinRequests screen transition changed from slideFromBottomInterpolator to slideFromRightInterpolator                           
- sheetModalTransitionSpec close spring changed from Springs.snappy to Springs.elegant                                            
- Login screen — removed unused forFadeFromCenter interpolator                                                                    
                                                                                                                                    
**BottomSheetModal.tsx**                                                                                                             
- Replaced hardcoded SLIDE_DISTANCE = 500 with actual screenHeight from useWindowDimensions                                       
- Close animation changed from spring finished callback to setTimeout(400ms) with cancel-on-reopen logic                          
                                                                                                                                    
**PendingRequestsScreen.tsx**                                                                                                        
- Changed edges={["top", "bottom"]} to edges={["bottom"]} — fixes the blank gap at the top of the Requests sheet

**After**
<img width="585" height="1266" alt="IMG_9175" src="https://github.com/user-attachments/assets/13bad995-66b0-43bd-9512-16aa7ddb2c9c" />
<img width="585" height="1266" alt="IMG_9176" src="https://github.com/user-attachments/assets/ebcb2f9c-8662-4483-92bf-f64c0d45f899" />
<img width="585" height="1266" alt="IMG_9177" src="https://github.com/user-attachments/assets/4dc968bb-2efc-400d-a56c-b75504581301" />
