### PR TITLE
Feature: Added confetti after event created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.26",
         "@react-navigation/stack": "^7.6.12",
+        "@shopify/react-native-skia": "^2.2.12",
         "expo": "^54.0.21",
         "expo-apple-authentication": "~8.0.7",
         "expo-blur": "^15.0.7",
@@ -5489,6 +5490,32 @@
         "react-native-screens": ">= 4.0.0"
       }
     },
+    "node_modules/@shopify/react-native-skia": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.2.12.tgz",
+      "integrity": "sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A==",
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "0.40.0",
+        "react-reconciler": "0.31.0"
+      },
+      "bin": {
+        "setup-skia-web": "scripts/setup-canvaskit.js"
+      },
+      "peerDependencies": {
+        "react": ">=19.0",
+        "react-native": ">=0.78",
+        "react-native-reanimated": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -6425,6 +6452,12 @@
         "@urql/core": "^5.0.0"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -7229,6 +7262,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz",
+      "integrity": "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -14170,6 +14212,27 @@
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
     "@react-navigation/stack": "^7.6.12",
+    "@shopify/react-native-skia": "^2.2.12",
     "expo": "^54.0.21",
     "expo-apple-authentication": "~8.0.7",
     "expo-blur": "^15.0.7",

--- a/src/components/ConfettiOverlay.tsx
+++ b/src/components/ConfettiOverlay.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo } from "react";
+import { StyleSheet, View, useWindowDimensions } from "react-native";
+import { Canvas, Circle, Group, Rect } from "@shopify/react-native-skia";
+import {
+    SharedValue,
+    makeMutable,
+    useDerivedValue,
+    useFrameCallback,
+    useSharedValue,
+} from "react-native-reanimated";
+
+// ─── Palettes ─────────────────────────────────────────────────────────────────
+const P: Record<string, string[]> = {
+    classic:    ["#FF6B6B", "#FFD93D", "#6BCB77", "#4D96FF", "#C77DFF", "#5EEAD4", "#FF9F43", "#FF6BFF"],
+    pastel:     ["#FFB3BA", "#FFDFBA", "#FFFFBA", "#BAFFC9", "#BAE1FF", "#E8BAFF", "#FFB3F7", "#B3FFF7"],
+    gold:       ["#FFD700", "#FFC107", "#FF9800", "#FFEB3B", "#FFA000", "#FFD54F", "#FFCA28", "#FFB300"],
+    neon:       ["#FF0099", "#00FF41", "#00E5FF", "#FFE600", "#FF6600", "#7700FF", "#00FFCC", "#FF0033"],
+    rainbow:    ["#FF0000", "#FF7700", "#FFFF00", "#00FF00", "#0000FF", "#8B00FF", "#FF00FF", "#00FFFF"],
+    fire:       ["#FF1A00", "#FF4500", "#FF8C00", "#FFC200", "#FFE500", "#FF6347", "#FF3D00", "#FFAB00"],
+    ocean:      ["#006994", "#0099CC", "#00B4D8", "#48CAE4", "#90E0EF", "#5EEAD4", "#22D3EE", "#0EA5E9"],
+    candy:      ["#FF6EB4", "#FF91D0", "#C77DFF", "#A78BFA", "#60A5FA", "#F472B6", "#E879F9", "#818CF8"],
+    forest:     ["#2D6A4F", "#40916C", "#52B788", "#74C69D", "#95D5B2", "#B7E4C7", "#6B8F71", "#1B4332"],
+    monochrome: ["#FFFFFF", "#F0F0F0", "#E0E0E0", "#D0D0D0", "#C0C0C0", "#B0B0B0", "#A0A0A0", "#FFFFFF"],
+    pride:      ["#FF0018", "#FFA52C", "#FFFF41", "#008018", "#0000F9", "#86007D", "#FF69B4", "#FFFFFF"],
+};
+
+const COUNT = 50;
+const DEG_TO_RAD = Math.PI / 180;
+
+export type ConfettiVariant =
+    | "classic" | "bubbles" | "ribbons" | "squares" | "big"
+    | "tiny" | "coins" | "ticker" | "chunky" | "wide"
+    | "dots" | "elongated" | "mixed" | "uniform" | "fat_circles"
+    | "pastel" | "gold" | "neon" | "rainbow" | "fire"
+    | "ocean" | "candy" | "forest" | "monochrome" | "pride"
+    | "slow" | "fast" | "burst" | "rise" | "storm" | "float" | "sideways";
+
+// ─── Physics ──────────────────────────────────────────────────────────────────
+type SpawnMode = "top" | "bottom" | "center" | "left";
+
+type Physics = {
+    gravity:  number;
+    spawn:    SpawnMode;
+    vxRange:  [number, number];
+    vyRange:  [number, number];
+    vrScale:  number;
+    delayMax: number;
+};
+
+const PHYSICS: Partial<Record<ConfettiVariant, Physics>> = {
+    slow:     { gravity: 90,  spawn: "top",    vxRange: [-50,  50],  vyRange: [15,  60],  vrScale: 0.35, delayMax: 1200 },
+    fast:     { gravity: 900, spawn: "top",    vxRange: [-200, 200], vyRange: [140, 420], vrScale: 2.0,  delayMax: 350  },
+    burst:    { gravity: 260, spawn: "center", vxRange: [180,  500], vyRange: [0,   0],   vrScale: 2.2,  delayMax: 180  },
+    rise:     { gravity: 180, spawn: "bottom", vxRange: [-130, 130], vyRange: [-480, -100], vrScale: 1.6, delayMax: 600 },
+    storm:    { gravity: 480, spawn: "top",    vxRange: [220,  520], vyRange: [50,  220], vrScale: 1.8,  delayMax: 300  },
+    float:    { gravity: 30,  spawn: "top",    vxRange: [-25,  25],  vyRange: [8,   28],  vrScale: 0.15, delayMax: 1800 },
+    sideways: { gravity: 280, spawn: "left",   vxRange: [160,  380], vyRange: [-40, 160], vrScale: 1.4,  delayMax: 500  },
+};
+
+const DEFAULT_PHYSICS: Physics = {
+    gravity: 420, spawn: "top", vxRange: [-80, 80], vyRange: [60, 240], vrScale: 1, delayMax: 700,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function seededRand(seed: number): number {
+    const x = Math.sin(seed + 1) * 39482.3741;
+    return x - Math.floor(x);
+}
+
+type Config = { color: string; w: number; h: number; isCircle: boolean };
+type State  = {
+    x: number; y: number;
+    vx: number; vy: number;
+    rotation: number; vr: number;
+    opacity: number;
+    delay: number;
+};
+type RenderState = { x: number; y: number; r: number; a: number };
+
+const makeConfigs = (variant: ConfettiVariant): Config[] =>
+    Array.from({ length: COUNT }, (_, i) => {
+        const r1    = seededRand(i * 9);
+        const r2    = seededRand(i * 9 + 1);
+        const r3    = seededRand(i * 9 + 2);
+        const pal   = P[variant] ?? P.classic;
+        const color = pal[i % pal.length];
+
+        switch (variant) {
+            case "bubbles":   { const d = 8 + r1 * 14; return { color, w: d, h: d, isCircle: true }; }
+            case "ribbons":     return { color, w: 3 + r1 * 3, h: 24 + r2 * 24, isCircle: false };
+            case "squares":   { const s = 7 + r1 * 9; return { color, w: s, h: s, isCircle: false }; }
+            case "big":       { const d = 14 + r1 * 16; return { color, w: d, h: r3 > 0.5 ? d : d * (1.2 + r2 * 0.8), isCircle: r3 > 0.65 }; }
+            case "tiny":        return { color, w: 2 + r1 * 4, h: 2 + r2 * 4, isCircle: r3 > 0.4 };
+            case "coins":       return { color, w: 14, h: 14, isCircle: true };
+            case "ticker":      return { color, w: 2 + r1 * 2, h: 30 + r2 * 26, isCircle: false };
+            case "chunky":    { const s = 12 + r1 * 10; return { color, w: s, h: s * (0.8 + r2 * 0.4), isCircle: r3 > 0.7 }; }
+            case "wide":        return { color, w: 14 + r1 * 12, h: 5 + r2 * 5, isCircle: false };
+            case "dots":      { const d = 4 + r1 * 6; return { color, w: d, h: d, isCircle: true }; }
+            case "elongated":   return { color, w: 4 + r1 * 3, h: 22 + r2 * 20, isCircle: false };
+            case "mixed":     { const sc = r3 < 0.25 ? 0.35 : r3 > 0.75 ? 2.2 : 1; return { color, w: (5 + r1 * 8) * sc, h: (7 + r2 * 10) * sc, isCircle: r3 > 0.5 }; }
+            case "uniform":     return { color, w: 8, h: 12, isCircle: false };
+            case "fat_circles": { const d = 12 + r1 * 10; return { color, w: d, h: d, isCircle: true }; }
+            case "burst":
+            case "rise":
+            case "storm":
+            case "float":
+            case "sideways":    return { color: P.classic[i % P.classic.length], w: 6 + r1 * 9, h: 10 + r2 * 12, isCircle: r3 > 0.62 };
+            default:            return { color, w: 6 + r1 * 9, h: 10 + r2 * 12, isCircle: r3 > 0.62 };
+        }
+    });
+
+const makeState = (i: number, screenW: number, screenH: number, physics: Physics, speedScale = 1): State => {
+    const r3 = seededRand(i * 9 + 3);
+    const r4 = seededRand(i * 9 + 4);
+    const r5 = seededRand(i * 9 + 5);
+    const r6 = seededRand(i * 9 + 6);
+    const r7 = seededRand(i * 9 + 7);
+    const r8 = seededRand(i * 9 + 8);
+    const r9 = seededRand(i * 9 + 9);
+
+    let x: number, y: number, vx: number, vy: number;
+
+    switch (physics.spawn) {
+        case "bottom":
+            x  = r3 * screenW;
+            y  = screenH + 10 + r4 * 30;
+            vx = physics.vxRange[0] + r5 * (physics.vxRange[1] - physics.vxRange[0]);
+            vy = physics.vyRange[0] + r6 * (physics.vyRange[1] - physics.vyRange[0]);
+            break;
+        case "center": {
+            const angle = r5 * Math.PI * 2;
+            const speed = (physics.vxRange[0] + r6 * (physics.vxRange[1] - physics.vxRange[0])) * speedScale;
+            x  = screenW / 2 + (r3 - 0.5) * 50;
+            y  = screenH / 2 + (r4 - 0.5) * 50;
+            vx = Math.cos(angle) * speed;
+            vy = Math.sin(angle) * speed;
+            break;
+        }
+        case "left":
+            x  = -(10 + r3 * 30);
+            y  = r4 * screenH * 0.8;
+            vx = physics.vxRange[0] + r5 * (physics.vxRange[1] - physics.vxRange[0]);
+            vy = physics.vyRange[0] + r6 * (physics.vyRange[1] - physics.vyRange[0]);
+            break;
+        default: // top
+            x  = r3 * screenW;
+            y  = -(20 + r4 * 80);
+            vx = physics.vxRange[0] + r5 * (physics.vxRange[1] - physics.vxRange[0]);
+            vy = physics.vyRange[0] + r6 * (physics.vyRange[1] - physics.vyRange[0]);
+            break;
+    }
+
+    return {
+        x, y, vx, vy,
+        rotation: r7 * 360,
+        vr:       (r8 - 0.5) * 480 * physics.vrScale,
+        opacity:  0,
+        delay:    r9 * physics.delayMax,
+    };
+};
+
+// ─── Single Skia particle ─────────────────────────────────────────────────────
+// Rendered inside a <Canvas> — no native View overhead, drawn in one GPU pass.
+const SkiaPiece = ({
+    config,
+    renderValue,
+}: {
+    config: Config;
+    renderValue: SharedValue<RenderState>;
+}) => {
+    const transform = useDerivedValue(() => {
+        const { x, y, r } = renderValue.value;
+        return [{ translateX: x }, { translateY: y }, { rotate: r * DEG_TO_RAD }];
+    });
+    const opacity = useDerivedValue(() => renderValue.value.a);
+
+    return (
+        <Group transform={transform} opacity={opacity}>
+            {config.isCircle
+                ? <Circle cx={config.w / 2} cy={config.w / 2} r={config.w / 2} color={config.color} />
+                : <Rect x={0} y={0} width={config.w} height={config.h} color={config.color} />
+            }
+        </Group>
+    );
+};
+
+// ─── Overlay ──────────────────────────────────────────────────────────────────
+type Props = { active: boolean; variant?: ConfettiVariant; speedScale?: number };
+
+const ConfettiOverlay = ({ active, variant = "burst", speedScale = 1 }: Props) => {
+    const { width, height } = useWindowDimensions();
+
+    const configs = useMemo(() => makeConfigs(variant), [variant]);
+    const physics = PHYSICS[variant] ?? DEFAULT_PHYSICS;
+
+    const renderValues = useMemo(
+        () => Array.from({ length: COUNT }, () =>
+            makeMutable<RenderState>({ x: 0, y: -5000, r: 0, a: 0 })
+        ),
+        []
+    );
+
+    const simStates = useSharedValue<State[]>(
+        Array.from({ length: COUNT }, (_, i) => makeState(i, width, height, physics))
+    );
+    const running = useSharedValue(false);
+    const gravity = useSharedValue(physics.gravity);
+
+    useEffect(() => {
+        const p = PHYSICS[variant] ?? DEFAULT_PHYSICS;
+        gravity.value = p.gravity;
+        if (active) {
+            simStates.value = Array.from({ length: COUNT }, (_, i) =>
+                makeState(i, width, height, p, speedScale)
+            );
+            for (let i = 0; i < COUNT; i++) {
+                renderValues[i].value = { x: 0, y: -5000, r: 0, a: 0 };
+            }
+            running.value = true;
+        } else {
+            running.value = false;
+        }
+    }, [active, variant]);
+
+    useFrameCallback((info) => {
+        if (!running.value) return;
+
+        const dt        = Math.min(info.timeSincePreviousFrame ?? 16.67, 33) / 1000;
+        const g         = gravity.value;
+        const s         = simStates.value;
+        const fadeStart = height * 0.72;
+        let   anyActive = false;
+
+        for (let i = 0; i < COUNT; i++) {
+            const offScreen = s[i].opacity === 0
+                && (s[i].y >= height || s[i].x > width + 250 || s[i].x < -250);
+            if (offScreen) continue;
+
+            if (s[i].delay > 0) {
+                s[i].delay -= dt * 1000;
+                anyActive = true;
+                continue;
+            }
+
+            s[i].y        += s[i].vy * dt;
+            s[i].vy       += g * dt;
+            s[i].x        += s[i].vx * dt;
+            s[i].rotation += s[i].vr * dt;
+
+            const gone = s[i].y >= height || s[i].x > width + 250 || s[i].x < -250;
+            if (gone) {
+                s[i].opacity = 0;
+            } else if (s[i].y > fadeStart) {
+                s[i].opacity = 1 - (s[i].y - fadeStart) / (height - fadeStart);
+                anyActive = true;
+            } else {
+                s[i].opacity = Math.min(1, s[i].opacity + dt * 6);
+                anyActive = true;
+            }
+
+            renderValues[i].value = { x: s[i].x, y: s[i].y, r: s[i].rotation, a: s[i].opacity };
+        }
+
+        simStates.value = [...s];
+        if (!anyActive) running.value = false;
+    });
+
+    if (!active) return null;
+
+    return (
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            <Canvas style={StyleSheet.absoluteFill}>
+                {configs.map((config, i) => (
+                    <SkiaPiece key={i} config={config} renderValue={renderValues[i]} />
+                ))}
+            </Canvas>
+        </View>
+    );
+};
+
+export default ConfettiOverlay;

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -42,6 +42,7 @@ import EditProfileScreen from "@screens/EditProfileScreen";
 import PastEventsScreen from "@screens/PastEventsScreen";
 import PrivacyPolicyScreen from "@screens/PrivacyPolicyScreen";
 import HelpScreen from "@screens/HelpScreen";
+import EventCreatedScreen from "@screens/EventCreatedScreen";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { BottomTabBarButtonProps } from "@react-navigation/bottom-tabs";
 
@@ -726,6 +727,15 @@ const AppNavigator = () => {
           options={{
             cardStyleInterpolator: slideFromRightInterpolator,
             transitionSpec: slideFromRightTransitionSpec,
+          }}
+        />
+        <Stack.Screen
+          name="EventCreated"
+          component={EventCreatedScreen}
+          options={{
+            gestureEnabled: false,
+            cardStyleInterpolator: CardStyleInterpolators.forNoAnimation,
+            cardStyle: { backgroundColor: "#111" },
           }}
         />
       </Stack.Navigator>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -30,6 +30,12 @@ export type RootStackParamList = {
   PrivacyPolicy: undefined;
   Help: undefined;
   Login: undefined;
+  EventCreated: {
+    eventTitle: string;
+    coverUri: string;
+    buttonLayout: { x: number; y: number; width: number; height: number };
+    skipAnimation?: boolean;
+  };
 };
 
 export type RootTabParamList = {

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -4,10 +4,21 @@ import {
     Keyboard,
     Platform,
     Pressable,
+    StyleSheet,
     Text,
     TextInput,
     View,
 } from "react-native";
+import Animated, {
+    Easing,
+    useAnimatedStyle,
+    useSharedValue,
+    withRepeat,
+    withSequence,
+    withTiming,
+} from "react-native-reanimated";
+import { LinearGradient } from "expo-linear-gradient";
+import MaskedView from "@react-native-masked-view/masked-view";
 
 import { SafeAreaView } from "react-native-safe-area-context";
 import * as Haptics from "expo-haptics";
@@ -15,6 +26,7 @@ import { BlurView } from "expo-blur";
 import CloseIcon from "@assets/ui/close.svg";
 import {
     RouteProp,
+    StackActions,
     useFocusEffect,
     useNavigation,
     useRoute,
@@ -59,6 +71,8 @@ import EventDateTimeModal from "@components/EventDateTimeModal";
 import BottomSheetModal from "../components/BottomSheetModal";
 import SignInButtons from "../components/SignInButtons";
 import styles from "./CreateEventScreen.styles";
+
+type ButtonLayout = { x: number; y: number; width: number; height: number };
 
 type FormState = {
     eventName: string;
@@ -164,6 +178,29 @@ const CreateEventScreen = () => {
     // Submission state
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
+
+    // Button layout for wow transition
+    const [buttonLayout, setButtonLayout] = useState<ButtonLayout>({ x: 0, y: 0, width: 0, height: 0 });
+    const primaryButtonRef = useRef<View>(null);
+
+    // Shimmer animation for "Creating event..." state
+    const shimmerX = useSharedValue(-160);
+    const shimmerStyle = useAnimatedStyle(() => ({
+        transform: [{ translateX: shimmerX.value }],
+    }));
+
+    useEffect(() => {
+        if (isSubmitting && !isEditing) {
+            shimmerX.value = -160;
+            shimmerX.value = withRepeat(
+                withSequence(
+                    withTiming(360, { duration: 1100, easing: Easing.linear }),
+                    withTiming(-160, { duration: 0 }),
+                ),
+                -1
+            );
+        }
+    }, [isSubmitting]);
 
     // Temporary selection states for modal confirmation
     const [tempAgeRange, setTempAgeRange] = useState<[number, number]>(ageRange);
@@ -402,6 +439,7 @@ const CreateEventScreen = () => {
                         showEventUpdatedBadge: true,
                     });
                 } else {
+                    const minDelay = new Promise<void>(r => setTimeout(r, 1500));
                     await addUserEvent({
                         title: trimmedName || "New event",
                         location: locationLabel,
@@ -421,12 +459,15 @@ const CreateEventScreen = () => {
                         hostName: user.name,
                         scheduledAt,
                     });
+                    await minDelay;
                     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
                     resetForm();
-                    (navigation as any).navigate("Main", {
-                        screen: "MyEvents",
-                        params: { showEventCreatedBadge: true },
-                    });
+                    navigation.dispatch(StackActions.replace("EventCreated", {
+                        eventTitle: trimmedName || "New event",
+                        coverUri: selectedCoverUri,
+                        buttonLayout,
+                        skipAnimation: true,
+                    }));
                 }
             } catch (err) {
                 console.error("Failed to submit event", err);
@@ -440,12 +481,14 @@ const CreateEventScreen = () => {
         },
         [
             addUserEvent,
+            buttonLayout,
             editEventId,
             getCurrentFormState,
             isEditing,
             isSubmitting,
             navigation,
             resetForm,
+            selectedCoverUri,
             updateUserEvent,
             user,
         ],
@@ -725,6 +768,12 @@ const CreateEventScreen = () => {
                 ) : null}
 
                 <Pressable
+                    ref={primaryButtonRef as any}
+                    onLayout={() => {
+                        primaryButtonRef.current?.measureInWindow((x, y, w, h) => {
+                            setButtonLayout({ x, y, width: w, height: h });
+                        });
+                    }}
                     style={[
                         styles.primaryButton,
                         isSubmitting && styles.primaryButtonDisabled,
@@ -734,9 +783,32 @@ const CreateEventScreen = () => {
                     accessibilityRole="button"
                     testID="create-event-submit"
                 >
-                    <Text style={styles.primaryButtonText}>
-                        {primaryButtonLabel}
-                    </Text>
+                    {isSubmitting && !isEditing ? (
+                        <MaskedView
+                            style={shimmerStyles.root}
+                            maskElement={
+                                <View style={shimmerStyles.mask}>
+                                    <Text style={styles.primaryButtonText}>Creating event...</Text>
+                                </View>
+                            }
+                        >
+                            <View style={shimmerStyles.mask}>
+                                <Text style={[styles.primaryButtonText, shimmerStyles.dimText]}>
+                                    Creating event...
+                                </Text>
+                            </View>
+                            <Animated.View style={[shimmerStyles.strip, shimmerStyle]} pointerEvents="none">
+                                <LinearGradient
+                                    colors={["transparent", "rgba(255,255,255,0.8)", "transparent"]}
+                                    start={{ x: 0, y: 0.5 }}
+                                    end={{ x: 1, y: 0.5 }}
+                                    style={StyleSheet.absoluteFill}
+                                />
+                            </Animated.View>
+                        </MaskedView>
+                    ) : (
+                        <Text style={styles.primaryButtonText}>{primaryButtonLabel}</Text>
+                    )}
                 </Pressable>
             </View>
         </>
@@ -838,8 +910,29 @@ const CreateEventScreen = () => {
             <BottomSheetModal visible={signInVisible} onClose={() => setSignInVisible(false)}>
                 <SignInButtons />
             </BottomSheetModal>
+
         </View>
     );
 };
+
+const shimmerStyles = StyleSheet.create({
+    root: {
+        alignItems: "center",
+    },
+    mask: {
+        backgroundColor: "transparent",
+        alignItems: "center",
+    },
+    dimText: {
+        opacity: 0.45,
+    },
+    strip: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 0,
+        width: 160,
+    },
+});
 
 export default CreateEventScreen;

--- a/src/screens/EventCreatedScreen.tsx
+++ b/src/screens/EventCreatedScreen.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+    Image,
+    StyleSheet,
+    Text,
+    View,
+    useWindowDimensions,
+} from "react-native";
+import Animated, {
+    Easing,
+    runOnJS,
+    useAnimatedStyle,
+    useSharedValue,
+    withDelay,
+    withRepeat,
+    withSequence,
+    withSpring,
+    withTiming,
+} from "react-native-reanimated";
+import { useMemo } from "react";
+import { LinearGradient } from "expo-linear-gradient";
+import MaskedView from "@react-native-masked-view/masked-view";
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+import { Springs } from "@theme/springs";
+import { typography } from "@theme/index";
+import { RootStackParamList } from "@navigation/types";
+
+type EventCreatedRoute = RouteProp<RootStackParamList, "EventCreated">;
+type EventCreatedNavigation = NativeStackNavigationProp<RootStackParamList, "EventCreated">;
+
+const EventCreatedScreen = () => {
+    const { width, height } = useWindowDimensions();
+    const route = useRoute<EventCreatedRoute>();
+    const navigation = useNavigation<EventCreatedNavigation>();
+
+    const { eventTitle, coverUri, buttonLayout, skipAnimation } = route.params;
+
+    const onCompleteRef = useRef(() => {
+        navigation.navigate("Main" as any, {
+            screen: "MyEvents",
+            params: { showEventCreatedBadge: true },
+        });
+    });
+
+    const done = useCallback(() => { onCompleteRef.current?.(); }, []);
+
+    // Button geometry as shared values
+    const btnCX = useSharedValue(buttonLayout.x + buttonLayout.width  / 2 - width  / 2);
+    const btnCY = useSharedValue(buttonLayout.y + buttonLayout.height / 2 - height / 2);
+    const btnSX = useSharedValue(buttonLayout.width  / width  || 0.85);
+    const btnSY = useSharedValue(buttonLayout.height / height || 0.06);
+
+    const expandProgress = useSharedValue(0);
+    const contentAlpha   = useSharedValue(0);
+    const screenAlpha    = useSharedValue(1);
+    const cardBobY       = useSharedValue(0);
+    const shimmerX       = useSharedValue(-200);
+
+    useEffect(() => {
+        if (skipAnimation) { done(); return; }
+        // 1 · White rect expands from button position to fill screen
+        expandProgress.value = withSpring(1, Springs.bouncyUp, () => {
+            // 2 · Content fades in
+            contentAlpha.value = withTiming(1, { duration: 240 });
+
+            // 3 · Card bobs slowly up ↔ down
+            cardBobY.value = withDelay(80, withRepeat(
+                withSequence(
+                    withTiming(-10, { duration: 1700, easing: Easing.inOut(Easing.sin) }),
+                    withTiming(10,  { duration: 1700, easing: Easing.inOut(Easing.sin) }),
+                ),
+                -1
+            ));
+
+            // 4 · Looping AI-thinking shimmer on "Creating event..."
+            shimmerX.value = -200;
+            shimmerX.value = withRepeat(
+                withSequence(
+                    withTiming(width + 200, { duration: 1200, easing: Easing.linear }),
+                    withTiming(-200, { duration: 50 }),
+                ),
+                -1
+            );
+
+            // 5 · After 2200 ms display, navigate first (while still white), then fade
+            // done() fires at 2200ms → CommonActions.reset removes this screen instantly
+            // (forNoAnimation), so MyEvents appears before any fade is visible
+            screenAlpha.value = withDelay(2200, withSequence(
+                withTiming(1, { duration: 0 }, () => { runOnJS(done)(); }),
+                withTiming(0, { duration: 300 })
+            ));
+        });
+    }, []);
+
+    const expandStyle = useAnimatedStyle(() => {
+        const p  = expandProgress.value;
+        const sx = btnSX.value + (1 - btnSX.value) * p;
+        const sy = btnSY.value + (1 - btnSY.value) * p;
+        return {
+            transform: [
+                { translateX: btnCX.value * (1 - p) },
+                { translateY: btnCY.value * (1 - p) },
+                { scaleX: sx },
+                { scaleY: sy },
+            ],
+            borderRadius: 999 * (1 - p),
+        };
+    });
+
+    const sScreen  = useAnimatedStyle(() => ({ opacity: screenAlpha.value }));
+    const sContent = useAnimatedStyle(() => ({ opacity: contentAlpha.value }));
+    const sCard    = useAnimatedStyle(() => ({ transform: [{ translateY: cardBobY.value }] }));
+    const sShimmer = useAnimatedStyle(() => ({ transform: [{ translateX: shimmerX.value }] }));
+
+    const cardSize = Math.round(width * 0.60);
+
+    // Static initial style applied before Reanimated's first frame so the white
+    // rect is never full-screen: it starts at button size/position immediately.
+    const whiteRectInitialStyle = useMemo(() => ({
+        transform: [
+            { translateX: buttonLayout.x + buttonLayout.width  / 2 - width  / 2 },
+            { translateY: buttonLayout.y + buttonLayout.height / 2 - height / 2 },
+            { scaleX: (buttonLayout.width  / width)  || 0.85 },
+            { scaleY: (buttonLayout.height / height) || 0.06 },
+        ],
+        borderRadius: 999,
+    }), []);
+
+    return (
+        <Animated.View style={[StyleSheet.absoluteFill, styles.root, sScreen]}>
+            {/* Same dark blurred background as CreateEventScreen — cut is invisible */}
+            <Image source={{ uri: coverUri }} style={StyleSheet.absoluteFill} resizeMode="cover" blurRadius={28} />
+            <View style={styles.backgroundOverlay} />
+
+            {/* White rect — starts at button size/position, expands to fill screen.
+                whiteRectInitialStyle seeds the correct transform before Reanimated
+                applies expandStyle, preventing a full-screen white flash on frame 0. */}
+            <Animated.View style={[StyleSheet.absoluteFill, styles.whiteRect, whiteRectInitialStyle, expandStyle]}>
+
+                {/* Content — only visible once expansion settles */}
+                <Animated.View style={[StyleSheet.absoluteFill, styles.contentLayer, sContent]}>
+
+                    {/* Floating cover card */}
+                    <Animated.View style={sCard}>
+                        <View style={[styles.card, { width: cardSize, height: cardSize }]}>
+                            {coverUri
+                                ? <Image source={{ uri: coverUri }} style={StyleSheet.absoluteFill} resizeMode="cover" />
+                                : <View style={[StyleSheet.absoluteFill, styles.cardFallback]} />
+                            }
+                        </View>
+                    </Animated.View>
+
+                    <View style={styles.textBlock}>
+                        {/* Event name */}
+                        <Text style={styles.eventName}>{eventTitle}</Text>
+
+                        {/* "Creating event..." — looping shimmer */}
+                        <MaskedView
+                            style={styles.maskedRoot}
+                            maskElement={
+                                <View style={styles.maskShape}>
+                                    <Text style={styles.creatingLabel}>Creating event...</Text>
+                                </View>
+                            }
+                        >
+                            <View style={styles.maskShape}>
+                                <Text style={[styles.creatingLabel, styles.dimGrey]}>Creating event...</Text>
+                            </View>
+                            <Animated.View style={[styles.shimmerStrip, sShimmer]} pointerEvents="none">
+                                <LinearGradient
+                                    colors={["transparent", "rgba(255,255,255,0.85)", "transparent"]}
+                                    start={{ x: 0, y: 0.5 }}
+                                    end={{ x: 1, y: 0.5 }}
+                                    style={StyleSheet.absoluteFill}
+                                />
+                            </Animated.View>
+                        </MaskedView>
+                    </View>
+
+                </Animated.View>
+            </Animated.View>
+        </Animated.View>
+    );
+};
+
+const styles = StyleSheet.create({
+    root: {
+        backgroundColor: "#111",
+    },
+    backgroundOverlay: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+    },
+    whiteRect: {
+        backgroundColor: "#FFFFFF",
+        overflow: "hidden",
+    },
+    contentLayer: {
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 28,
+    },
+    card: {
+        borderRadius: 24,
+        overflow: "hidden",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 8 },
+        shadowOpacity: 0.12,
+        shadowRadius: 24,
+        elevation: 10,
+    },
+    cardFallback: {
+        backgroundColor: "#F0F0F0",
+    },
+    textBlock: {
+        alignItems: "center",
+        gap: 8,
+    },
+    eventName: {
+        fontSize: 20,
+        fontFamily: typography.fontFamilySemiBold,
+        color: "#111111",
+        lineHeight: 24,
+        letterSpacing: -0.5,
+        textAlign: "center",
+        paddingHorizontal: 28,
+    },
+    maskedRoot: {
+        alignItems: "center",
+    },
+    maskShape: {
+        backgroundColor: "transparent",
+        alignItems: "center",
+    },
+    creatingLabel: {
+        fontSize: 15,
+        fontFamily: typography.fontFamilyMedium,
+        color: "#fff",
+        letterSpacing: 0.1,
+    },
+    dimGrey: {
+        color: "#B8B8B8",
+    },
+    shimmerStrip: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 0,
+        width: 200,
+    },
+});
+
+export default EventCreatedScreen;

--- a/src/screens/MyEventsScreen.tsx
+++ b/src/screens/MyEventsScreen.tsx
@@ -28,6 +28,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import EmptyState from "@components/EmptyState";
 import EventActionBadge from "@components/EventActionBadge";
+import ConfettiOverlay from "@components/ConfettiOverlay";
 import EventCard, { EventItemProps } from "@components/EventCard";
 import ScreenContainer from "@components/ScreenContainer";
 import { RootStackParamList, RootTabParamList } from "@navigation/types";
@@ -103,7 +104,6 @@ const MyEventsScreen = () => {
   const { conversations } = useChat();
   const { user } = useAuth();
   const insets = useSafeAreaInsets();
-
   const [selectedPage, setSelectedPage] = useState(0);
   const pageOffset = useSharedValue(0);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -114,8 +114,7 @@ const MyEventsScreen = () => {
 
   useEffect(() => {
     if (!route.params?.showEventCreatedBadge) return;
-    const t = setTimeout(() => setShowEventCreatedBadge(true), 350);
-    return () => clearTimeout(t);
+    setShowEventCreatedBadge(true);
   }, [route.params?.showEventCreatedBadge]);
 
   useEffect(() => {
@@ -203,8 +202,8 @@ const MyEventsScreen = () => {
 
   if (!user) {
     return (
-      <ScreenContainer>
-        <View style={styles.headerSpacing}>
+      <ScreenContainer edges={["bottom"]}>
+        <View style={[styles.headerSpacing, { paddingTop: insets.top + (spacing.lg - spacing.md) }]}>
           <Text style={styles.headerTitle}>My Events</Text>
         </View>
         <EmptyState
@@ -224,7 +223,8 @@ const MyEventsScreen = () => {
   }
 
   return (
-    <ScreenContainer>
+    <View style={styles.root}>
+    <ScreenContainer edges={["bottom"]}>
       <View style={styles.content}>
         <AnimatedPager
           selectedIndex={selectedPage}
@@ -289,7 +289,7 @@ const MyEventsScreen = () => {
 
         {/* Floating blurred header */}
         <View
-          style={styles.floatingHeader}
+          style={[styles.floatingHeader, { paddingTop: insets.top }]}
           onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}
         >
           <View style={styles.headerSpacing}>
@@ -325,10 +325,15 @@ const MyEventsScreen = () => {
         />
       </View>
     </ScreenContainer>
+    <ConfettiOverlay active={showEventCreatedBadge} variant="burst" speedScale={1.8} />
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
   floatingHeader: {
     position: "absolute",
     top: 0,


### PR DESCRIPTION
### Added confetti after event created

**New files**                                                                                                                        
- src/components/ConfettiOverlay.tsx — Custom confetti built on a Skia canvas. 50 particles with physics simulation on the UI thread (Reanimated useFrameCallback). All particles drawn in a single GPU pass via one <Canvas> instead of 50 separate            Animated.View nodes. Per-particle makeMutable shared values so updating one particle never re-evaluates the other 49 styles.
- src/screens/EventCreatedScreen.tsx — Intermediate screen in the create→MyEvents navigation path, with skipAnimation support to navigate instantly.                                                                                                             
                                                                                                                                    
**CreateEventScreen.tsx** — While the event is being saved, the submit button changes to "Creating event..." with a looping shimmer (MaskedView + LinearGradient + Reanimated). Enforces a 1.5s minimum display time, then navigates via                              StackActions.replace("EventCreated", { skipAnimation: true }) for a seamless dark-to-dark cut with no white flash.
                                                                                                                                    
**MyEventsScreen.tsx** — Three changes: (1) added <ConfettiOverlay variant="burst" speedScale={1.8} /> replacing the old              react-native-confetti-cannon, (2) confetti and badge now fire immediately on arrival (removed 350ms delay), (3) fixed the floating header shifting down on first render by bypassing SafeAreaView's deferred inset measurement — using edges={["bottom"]} on ScreenContainer and applying insets.top directly from useSafeAreaInsets().

**AppNavigator.tsx + types.ts** — Registered the EventCreated screen with forNoAnimation interpolator and cardStyle: {              backgroundColor: "#111" }.
                                                                                                                                    
**package.json** — Added @shopify/react-native-skia, removed unused react-native-confetti-cannon. 

**After**
<img width="585" height="1266" alt="View recent photos 5" src="https://github.com/user-attachments/assets/f267fc4e-40f9-4551-aaf9-18c2efe29cb0" />
