### PR TITLE
Fix/search create event

### DIFF
--- a/assets/create-event/search.svg
+++ b/assets/create-event/search.svg
@@ -1,0 +1,3 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.3269 14.44L17.8 17.8M16.68 8.84C16.68 13.1699 13.1699 16.68 8.84 16.68C4.51009 16.68 1 13.1699 1 8.84C1 4.51009 4.51009 1 8.84 1C13.1699 1 16.68 4.51009 16.68 8.84Z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12117,9 +12117,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12139,9 +12136,6 @@
       "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12163,9 +12157,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12185,9 +12176,6 @@
       "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     Keyboard,
     Modal,
-    Platform,
     Pressable,
     StyleSheet,
     Text,
@@ -12,9 +11,9 @@ import {
 import Animated, {
     useSharedValue,
     useAnimatedStyle,
+    useAnimatedKeyboard,
     withSpring,
     withTiming,
-    runOnJS,
     Easing,
 } from "react-native-reanimated";
 
@@ -31,24 +30,25 @@ export type BottomSheetModalProps = {
     children: React.ReactNode;
     /** Variant A: renders title + × header. Omit for Variant B (content-only). */
     title?: string;
+    /** Set to false to disable keyboard avoidance. Default: true. */
+    avoidKeyboard?: boolean;
+    /** Pin the sheet to an exact height instead of sizing to content. */
+    snapHeight?: number;
 };
 
 const BASE_PADDING_BOTTOM = 8;
 const MIN_TOP_GUTTER = 96;
 
-// Bezier approximation of iOS UIViewAnimationCurveKeyboard
-const IOS_KEYBOARD_EASING = Easing.bezier(0.36, 0.66, 0.04, 1);
-
-const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModalProps) => {
+const BottomSheetModal = ({ visible, onClose, children, title, avoidKeyboard = true, snapHeight }: BottomSheetModalProps) => {
     const { bottom: safeBottom, top: safeTop } = useSafeAreaInsets();
     const { height: screenHeight } = useWindowDimensions();
     const basePadding = BASE_PADDING_BOTTOM + safeBottom;
     const topGutter = Math.max(safeTop + 12, MIN_TOP_GUTTER);
     const sheetMaxHeight = Math.max(screenHeight - topGutter, screenHeight * 0.5);
 
+    const keyboard = useAnimatedKeyboard();
     const slideAnim = useSharedValue(screenHeight);
     const backdropAnim = useSharedValue(0);
-    const keyboardPaddingAnim = useSharedValue(basePadding);
     const [modalVisible, setModalVisible] = useState(false);
     const hasBeenVisible = useRef(false);
     const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -59,17 +59,20 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
     const backdropStyle = useAnimatedStyle(() => ({
         opacity: backdropAnim.value,
     }));
-    const keyboardStyle = useAnimatedStyle(() => ({
-        paddingBottom: keyboardPaddingAnim.value,
-    }));
+    const keyboardStyle = useAnimatedStyle(() => {
+        if (!avoidKeyboard) return { paddingBottom: basePadding };
+        const kbHeight = keyboard.height.value;
+        return {
+            paddingBottom: kbHeight > 0 ? kbHeight + 16 : basePadding,
+        };
+    });
 
     const startOpenAnimation = useCallback(() => {
         slideAnim.value = screenHeight;
         backdropAnim.value = 0;
-        keyboardPaddingAnim.value = basePadding;
         slideAnim.value = withSpring(0, Springs.bouncyUp);
         backdropAnim.value = withTiming(1, { duration: 100, easing: Easing.out(Easing.cubic) });
-    }, [basePadding, screenHeight]);
+    }, [screenHeight]);
 
     useEffect(() => {
         if (visible) {
@@ -79,65 +82,33 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
             }
             hasBeenVisible.current = true;
             setModalVisible(true);
-            // Animation starts in onShow, after the modal content is rendered
         } else if (hasBeenVisible.current) {
-            slideAnim.value = withSpring(screenHeight, Springs.elegant);
-            backdropAnim.value = withTiming(0, { duration: 120, easing: Easing.in(Easing.ease) });
-            dismissTimerRef.current = setTimeout(() => setModalVisible(false), 400);
+            Keyboard.dismiss();
+            slideAnim.value = withTiming(screenHeight, { duration: 280, easing: Easing.in(Easing.cubic) });
+            backdropAnim.value = withTiming(0, { duration: 200, easing: Easing.in(Easing.ease) });
+            dismissTimerRef.current = setTimeout(() => setModalVisible(false), 300);
         }
     }, [visible, screenHeight]);
 
-    useEffect(() => {
-        const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
-        const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
-
-        const showSub = Keyboard.addListener(showEvent, (event) => {
-            keyboardPaddingAnim.value = withTiming(event.endCoordinates.height + 16, {
-                duration: event.duration || 250,
-                easing: IOS_KEYBOARD_EASING,
-            });
-        });
-
-        const hideSub = Keyboard.addListener(hideEvent, (event) => {
-            keyboardPaddingAnim.value = withTiming(basePadding, {
-                duration: (event as any).duration || 250,
-                easing: IOS_KEYBOARD_EASING,
-            });
-        });
-
-        return () => {
-            showSub.remove();
-            hideSub.remove();
-        };
-    }, [basePadding]);
-
     return (
         <Modal visible={modalVisible} transparent animationType="none" statusBarTranslucent onShow={startOpenAnimation}>
-            {/* Full-screen Pressable handles backdrop dismiss */}
             <Pressable
                 style={StyleSheet.absoluteFill}
                 onPress={onClose}
                 testID="bottom-sheet-backdrop"
                 accessibilityRole="button"
             >
-                {/* Dim overlay — visual only, no touch */}
                 <Animated.View
                     style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
                     pointerEvents="none"
                 />
 
-                {/* Sheet is a child of the backdrop Pressable.
-                    onStartShouldSetResponder claims all touches within the sheet,
-                    preventing them from bubbling up to the backdrop Pressable.
-                    Child buttons are deeper so they still claim touches first. */}
                 <Animated.View
-                    style={[styles.sheet, { maxHeight: sheetMaxHeight }, sheetStyle]}
+                    style={[styles.sheet, { maxHeight: sheetMaxHeight }, snapHeight ? { height: snapHeight } : null, sheetStyle]}
                     testID="bottom-sheet-modal"
                     onStartShouldSetResponder={() => true}
                 >
-                    {/* Keyboard padding on a separate node since layout props
-                        can't share the same Animated.View as transform. */}
-                    <Animated.View style={[styles.keyboardContent, keyboardStyle]}>
+                    <Animated.View style={[styles.keyboardContent, keyboardStyle, snapHeight ? { flex: 1 } : null]}>
                         {title !== undefined && (
                             <View style={styles.header}>
                                 <Text style={styles.title}>{title}</Text>
@@ -161,6 +132,5 @@ const BottomSheetModal = ({ visible, onClose, children, title }: BottomSheetModa
         </Modal>
     );
 };
-
 
 export default BottomSheetModal;

--- a/src/components/LocationPickerModal.styles.ts
+++ b/src/components/LocationPickerModal.styles.ts
@@ -4,8 +4,6 @@ import { spacing, typography } from "@theme/index";
 
 const styles = StyleSheet.create({
     container: {
-        paddingHorizontal: spacing.md,
-        paddingBottom: spacing.xl,
     },
 
     // Search Bar — prominent, premium feel
@@ -17,7 +15,7 @@ const styles = StyleSheet.create({
         borderCurve: "continuous",
         paddingHorizontal: spacing.md,
         paddingVertical: 11,
-        marginBottom: spacing.md,
+        marginBottom: 0,
         gap: spacing.sm,
     },
     searchInput: {
@@ -26,26 +24,18 @@ const styles = StyleSheet.create({
         fontSize: 17,
         fontFamily: typography.fontFamilyRegular,
         color: "#1C1C1E",
-        lineHeight: 22,
         padding: 0,
         letterSpacing: -0.3,
     },
     resultsList: {
-        flexGrow: 0,
-        flexShrink: 0,
+        flex: 1,
     },
     resultsContent: {
         flexGrow: 1,
-        paddingBottom: spacing.sm,
+        paddingBottom: 30,
     },
     resultsContentCentered: {
         justifyContent: "center",
-    },
-    clearButton: {
-        width: 24,
-        height: 24,
-        justifyContent: "center",
-        alignItems: "center",
     },
 
     // Result Row
@@ -116,6 +106,29 @@ const styles = StyleSheet.create({
         color: "#8E8E93",
         textAlign: "center",
         lineHeight: 20,
+        letterSpacing: -0.2,
+    },
+
+    // Inline Hint (searching / typing / empty)
+    inlineLoadingContainer: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingTop: spacing.md,
+        paddingHorizontal: 4,
+        gap: spacing.sm,
+    },
+    inlineHint: {
+        fontSize: 15,
+        fontFamily: typography.fontFamilyMedium,
+        color: "#8E8E93",
+        paddingTop: spacing.md,
+        paddingHorizontal: 4,
+        letterSpacing: -0.2,
+    },
+    inlineHintNopad: {
+        fontSize: 15,
+        fontFamily: typography.fontFamilyMedium,
+        color: "#8E8E93",
         letterSpacing: -0.2,
     },
 

--- a/src/components/LocationPickerModal.tsx
+++ b/src/components/LocationPickerModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
     ActivityIndicator,
-    Keyboard,
     Pressable,
     ScrollView,
     Text,
@@ -11,9 +10,7 @@ import {
 } from "react-native";
 
 import BottomSheetModal from "./BottomSheetModal";
-import SearchIcon from "@assets/ui/search.svg";
-import CloseIcon from "@assets/ui/close.svg";
-import LocationPinIcon from "@assets/ui/location-pin.svg";
+import SearchIcon from "@assets/create-event/search.svg";
 import {
     usePlacesAutocomplete,
     fetchPlaceDetails,
@@ -40,8 +37,8 @@ const LocationPickerModal = ({
     const { results, loading, error: autocompleteError, search, clear } = usePlacesAutocomplete();
     const [selectingId, setSelectingId] = useState<string | null>(null);
     const [selectionError, setSelectionError] = useState<string | null>(null);
-    const resultsListHeight = useMemo(
-        () => Math.round(Math.max(200, Math.min(windowHeight * 0.32, 320))),
+    const sheetHeight = useMemo(
+        () => Math.round(windowHeight * 0.9),
         [windowHeight],
     );
 
@@ -52,9 +49,13 @@ const LocationPickerModal = ({
                 search(initialQuery);
             }
         } else {
-            clear();
-            setSelectingId(null);
-            setSelectionError(null);
+            const timer = setTimeout(() => {
+                clear();
+                setQuery("");
+                setSelectingId(null);
+                setSelectionError(null);
+            }, 350);
+            return () => clearTimeout(timer);
         }
     }, [visible, initialQuery, search, clear]);
 
@@ -89,16 +90,14 @@ const LocationPickerModal = ({
     const showResults = hasQuery && !loading && !error;
     const showEmpty = hasQuery && !loading && !error && results.length === 0;
     const showTypingHint = query.length > 0 && query.length < 2 && !loading;
-    const showInitialHint = query.length === 0 && !loading;
-    const shouldCenterResults =
-        loading || Boolean(error) || showEmpty || showTypingHint || showInitialHint;
+    const shouldCenterResults = Boolean(error);
 
     return (
-        <BottomSheetModal visible={visible} onClose={onClose} title="Select Location">
-            <View style={styles.container}>
+        <BottomSheetModal visible={visible} onClose={onClose} title="Select Location" avoidKeyboard={false} snapHeight={sheetHeight}>
+            <View style={[styles.container, { flex: 1 }]}>
                 {/* Search Bar */}
                 <View style={styles.searchContainer}>
-                    <SearchIcon width={18} height={18} color="#8E8E93" />
+                    <SearchIcon width={16} height={16} color="#8E8E93" />
                     <TextInput
                         style={styles.searchInput}
                         placeholder="Search Location"
@@ -110,26 +109,13 @@ const LocationPickerModal = ({
                         underlineColorAndroid="transparent"
                         onSubmitEditing={() => search(query)}
                     />
-                    {query.length > 0 && (
-                        <Pressable
-                            style={styles.clearButton}
-                            onPress={() => {
-                                setQuery("");
-                                clear();
-                                setSelectionError(null);
-                            }}
-                            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                        >
-                            <CloseIcon width={14} height={14} color="#8E8E93" />
-                        </Pressable>
-                    )}
                 </View>
 
                 <ScrollView
-                    style={[styles.resultsList, { height: resultsListHeight }]}
+                    style={[styles.resultsList, { maxHeight: Math.round(windowHeight * 0.35) }]}
                     contentContainerStyle={[
                         styles.resultsContent,
-                        { minHeight: resultsListHeight },
+                        { flexGrow: 1 },
                         shouldCenterResults && styles.resultsContentCentered,
                     ]}
                     showsVerticalScrollIndicator={false}
@@ -137,9 +123,9 @@ const LocationPickerModal = ({
                 >
                     {/* Loading State */}
                     {loading && (
-                        <View style={styles.loadingContainer}>
-                            <ActivityIndicator color="#8E8E93" />
-                            <Text style={styles.loadingText}>Searching places...</Text>
+                        <View style={styles.inlineLoadingContainer}>
+                            <ActivityIndicator size="small" color="#8E8E93" />
+                            <Text style={styles.inlineHintNopad}>Searching places...</Text>
                         </View>
                     )}
 
@@ -155,38 +141,14 @@ const LocationPickerModal = ({
 
                     {/* Empty State */}
                     {showEmpty && (
-                        <View style={styles.emptyState}>
-                            <LocationPinIcon width={48} height={48} color="#C7C7CC" />
-                            <Text style={styles.emptyStateTitle}>
-                                No places found
-                            </Text>
-                            <Text style={styles.emptyStateText}>
-                                Try searching with a different name or more specific area
-                            </Text>
-                        </View>
+                        <Text style={styles.inlineHint}>No places with this name found</Text>
                     )}
 
                     {/* Typing Hint */}
                     {showTypingHint && (
-                        <View style={styles.emptyState}>
-                            <Text style={styles.emptyStateText}>
-                                Keep typing to discover places nearby...
-                            </Text>
-                        </View>
+                        <Text style={styles.inlineHint}>Keep typing to discover places nearby...</Text>
                     )}
 
-                    {/* Initial Hint */}
-                    {showInitialHint && (
-                        <View style={styles.emptyState}>
-                            <LocationPinIcon width={48} height={48} color="#C7C7CC" />
-                            <Text style={styles.emptyStateTitle}>
-                                Where&apos;s the vibe at?
-                            </Text>
-                            <Text style={styles.emptyStateText}>
-                                Search for restaurants, bars, cafes, or any cool spot for your event
-                            </Text>
-                        </View>
-                    )}
 
                     {/* Results */}
                     {showResults && results.length > 0 && (
@@ -199,7 +161,7 @@ const LocationPickerModal = ({
                                         pressed && styles.resultRowPressed,
                                     ]}
                                     onPress={() => {
-                                        Keyboard.dismiss();
+                                        onClose();
                                         handleSelect(prediction);
                                     }}
                                     disabled={selectingId === prediction.placeId}

--- a/src/screens/CreateEventScreen.styles.ts
+++ b/src/screens/CreateEventScreen.styles.ts
@@ -306,8 +306,7 @@ const styles = StyleSheet.create({
     },
     locationValuePill: {
         flexShrink: 1,
-        minWidth: "50%",
-        maxWidth: "72%",
+        maxWidth: "65%",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "flex-start",

--- a/src/screens/CreateEventScreen.styles.ts
+++ b/src/screens/CreateEventScreen.styles.ts
@@ -38,7 +38,8 @@ const styles = StyleSheet.create({
         alignItems: "center",
         paddingTop: spacing.sm,
         paddingBottom: spacing.sm,
-        paddingHorizontal: spacing.lg,
+        paddingLeft: spacing.lg,
+        paddingRight: 12,
     },
     // Invisible spacer on the left, same width as dismissButton, to keep title truly centered
     headerSpacer: {
@@ -305,9 +306,11 @@ const styles = StyleSheet.create({
     },
     locationValuePill: {
         flexShrink: 1,
+        minWidth: "50%",
         maxWidth: "72%",
         flexDirection: "row",
         alignItems: "center",
+        justifyContent: "flex-start",
         paddingHorizontal: 12,
     },
     locationPlaceholder: {

--- a/src/screens/CreateEventScreen.tsx
+++ b/src/screens/CreateEventScreen.tsx
@@ -71,7 +71,6 @@ import CoverPickerModal from "@components/CoverPickerModal";
 import EventDateTimeModal from "@components/EventDateTimeModal";
 import LocationPickerModal from "@components/LocationPickerModal";
 import type { PlaceDetail } from "@hooks/usePlacesAutocomplete";
-import LocationPinIcon from "@assets/ui/location-pin.svg";
 import BottomSheetModal from "../components/BottomSheetModal";
 import SignInButtons from "../components/SignInButtons";
 import styles from "./CreateEventScreen.styles";
@@ -813,14 +812,6 @@ const CreateEventScreen = () => {
                     >
                         <Text style={styles.fieldLabel}>Location</Text>
                         <View style={[styles.fieldValuePill, styles.locationValuePill]}>
-                            {selectedLocationLabel ? (
-                                <LocationPinIcon
-                                    width={14}
-                                    height={14}
-                                    color="rgba(255, 255, 255, 0.9)"
-                                    style={{ marginRight: 6 }}
-                                />
-                            ) : null}
                             <Text
                                 style={[
                                     styles.fieldValueText,


### PR DESCRIPTION
### LocationPickerModal (new component polish)
 
**Search bar**
- Replaced @assets/ui/search.svg with @assets/create-event/search.svg, fixed its stroke from black to currentColor so the color prop works 
- Icon size: 16×16, stroke-width: 2
- Removed lineHeight from TextInput to fix vertical alignment with the search icon
- Removed inline clear (×) button entirely
  
**Hints & states (all inline, just below search bar)**
- "Searching places..." — spinner + text in a row, no longer centered in the middle of the screen
- "Keep typing to discover places nearby..." — inline text
- "No places with this name found" — replaces old empty state (removed pin icon, title, description)
- Removed "Where's the vibe at?" initial hint entirely

**Sheet behaviour**
- Sheet opens at 90% screen height (snapHeight), avoidKeyboard: false — no jump when keyboard appears
- State clear (results, query, errors) delayed by 350ms to prevent empty state flash during dismiss animation
- onClose() fires immediately on result tap, fetchPlaceDetails runs in background — no pause before sheet closes

---

**BottomSheetModal (shared component)**
- Replaced keyboard event listeners with useAnimatedKeyboard() from Reanimated — keyboard avoidance now runs on the UI thread for smooth animation
- Added avoidKeyboard prop (default true)
- Added snapHeight prop to pin sheet to an exact height

---

**CreateEventScreen**

- Removed location pin icon from the location value pill
- Location pill: minWidth: 50%, justifyContent: flex-start so placeholder text is left-aligned
- Header paddingRight reduced from spacing.lg (24) to 12 to align the × with the sheet's × button
- Location pill now sizes dynamically to its content — starts at the width of the 'Select Location' placeholder and expands as 
  needed when a location is selected, capped at 65% of the row width.

---

**Assets**

- Added assets/create-event/search.svg (new file, stroke changed to currentColor)

---

**After**
<img width="585" height="1266" alt="IMG_9271" src="https://github.com/user-attachments/assets/3e0fbf80-56b8-4955-bae5-cfa90ee58eb8" />
<img width="585" height="1266" alt="IMG_9272" src="https://github.com/user-attachments/assets/98b68c33-4146-45d5-bc1a-14c3ce54cb46" />
<img width="585" height="1266" alt="IMG_9273" src="https://github.com/user-attachments/assets/d252fbee-10e6-4210-a8f5-8ed6b2c4a97f" />
<img width="585" height="1266" alt="IMG_9274" src="https://github.com/user-attachments/assets/ee0f091e-5abe-474c-a907-0b2b983d486e" />
<img width="585" height="1266" alt="IMG_9275" src="https://github.com/user-attachments/assets/94ddf7c0-823e-4ccc-bfc5-74499708ccda" />
<img width="585" height="1266" alt="IMG_9276" src="https://github.com/user-attachments/assets/bbbed4cd-6618-4666-90d8-48601be0f978" />
