### PR TITLE
fix: badge transition after event is created

### DIFF
--- a/src/components/EventActionBadge.tsx
+++ b/src/components/EventActionBadge.tsx
@@ -165,8 +165,6 @@ const styles = StyleSheet.create({
     borderCurve: "continuous",
     flexDirection: "row",
     alignItems: "center",
-    borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.12)",
   },
   blurClip: {
     borderRadius: 16,

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -204,7 +204,11 @@ const EventDetailsScreen = () => {
     if (!showEventUpdatedBadgeParam) {
       return;
     }
-    setShowEventUpdatedBadge(true);
+    const unsubscribe = navigation.addListener('transitionEnd', () => {
+      setShowEventUpdatedBadge(true);
+      unsubscribe();
+    });
+    return unsubscribe;
   }, [showEventUpdatedBadgeParam]);
 
   useEffect(() => {

--- a/src/screens/MyEventsScreen.tsx
+++ b/src/screens/MyEventsScreen.tsx
@@ -4,6 +4,7 @@ import BottomSheetModal from "@components/BottomSheetModal";
 import SignInButtons from "@components/SignInButtons";
 import SegmentedControl, { SegmentedOption } from "@components/SegmentedControl";
 import {
+  InteractionManager,
   RefreshControl,
   SectionList,
   SectionListRenderItemInfo,
@@ -114,13 +115,14 @@ const MyEventsScreen = () => {
 
   useEffect(() => {
     if (!route.params?.showEventCreatedBadge) return;
-    setShowEventCreatedBadge(true);
+    const task = InteractionManager.runAfterInteractions(() => setShowEventCreatedBadge(true));
+    return () => task.cancel();
   }, [route.params?.showEventCreatedBadge]);
 
   useEffect(() => {
     if (!route.params?.showEventDeletedBadge) return;
-    const t = setTimeout(() => setShowEventDeletedBadge(true), 350);
-    return () => clearTimeout(t);
+    const task = InteractionManager.runAfterInteractions(() => setShowEventDeletedBadge(true));
+    return () => task.cancel();
   }, [route.params?.showEventDeletedBadge]);
 
   const joinedEventIds = useMemo(() => {


### PR DESCRIPTION
1. Badge border removed
  The toast-style badge (e.g. "Event Created", "Event Deleted") had a subtle white border. Removed it so it looks cleaner.

  2. Event Created / Event Deleted badges in My Events — smarter timing
  Previously these badges either showed immediately (before the screen transition finished) or used a hardcoded 350ms delay. Now they wait for all screen animations to finish before appearing, using React Native's InteractionManager.
  
  3. Event Updated badge in Event Details — smarter timing
  Same idea — previously showed immediately. Now waits for the navigation transition to fully complete before appearing, so it no longer overlaps with the screen animation.

---

1. MyEventsScreen.tsx
  - EventCreated badge: replaced setShowEventCreatedBadge(true) (no delay) with InteractionManager.runAfterInteractions— waits for screen transition to finish before showing
  - EventDeleted badge: replaced setTimeout(350ms) with InteractionManager.runAfterInteractions — same approach, no hardcoded delay

  2. EventDetailsScreen.tsx
  - EventUpdated badge: replaced setShowEventUpdatedBadge(true) (no delay) with navigation.addListener('transitionEnd') — fires  after the stack transition completes

  3. EventActionBadge.tsx
  - Removed borderWidth: 1 and borderColor: "rgba(255,255,255,0.12)" — removed the border from the badge
  