### PR TITLE
polish: chat list scaling on scroll

### DIFF
--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -101,6 +101,7 @@ const ConversationRow = ({
     <ScalePressable
       onPress={() => onPress(item)}
       onPressIn={() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)}
+      delay={80}
       style={[styles.conversationRow, item.id === activeConversationId && styles.conversationRowActive]}
     >
       {hasUnread && <View testID={`conversation-unread-dot-${item.id}`} style={styles.unreadDot} />}


### PR DESCRIPTION
### Add scroll delay to chat list rows to prevent accidental scale on scroll

While scrolling through the chat list, tapping to open a conversation would sometimes accidentally trigger a scale animation on  the row — making it feel jittery. This fix adds an 80ms delay before the scale kicks in, so quick scroll touches are ignored. Only intentional taps trigger the animation. This matches the same behavior already used on event cards in the home screen.

  ---
  
**What Changed**
  
- src/screens/MessagesScreen.tsx — Added delay={80} to the ScalePressable wrapping each conversation row, preventing the scale-down animation from firing during scroll gestures