### PR TITLE
Polish/past events

### DIFF
--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -8,20 +8,23 @@ import {
   View,
 } from "react-native";
 import { useCallback, useState } from "react";
+import { BlurView } from "expo-blur";
 import ScalePressable from "@components/ScalePressable";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import * as Haptics from "expo-haptics";
 import CloseIcon from "@assets/ui/close.svg";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+
 
 import ScreenContainer from "@components/ScreenContainer";
 import ScreenHeader from "@components/ScreenHeader";
 import UserAvatar from "@components/UserAvatar";
-import { colors, spacing, typography } from "@theme/index";
+import { colors, typography } from "@theme/index";
 import { useAuth, type ApiError } from "@context/AuthContext";
 import { RootStackParamList } from "@navigation/types";
 import CameraIcon from "@assets/onboarding/camera.svg";
+import ProfileIcon from "@assets/onboarding/profile.svg";
+import { getAvatarColor } from "@utils/avatar";
 
 let ImagePicker: typeof import("expo-image-picker") | null = null;
 try {
@@ -35,8 +38,7 @@ type EditProfileNavigation = NativeStackNavigationProp<RootStackParamList>;
 const EditProfileScreen = () => {
   const navigation = useNavigation<EditProfileNavigation>();
   const { user, updateProfile } = useAuth();
-  const insets = useSafeAreaInsets();
-
+  const avatarColor = getAvatarColor(user?.id);
   const [editName, setEditName] = useState(user?.name ?? "");
   const [editAvatarBase64, setEditAvatarBase64] = useState<string | null>(null);
   const [removedAvatar, setRemovedAvatar] = useState(false);
@@ -139,15 +141,23 @@ const EditProfileScreen = () => {
         <View style={styles.avatarSection}>
           <View style={styles.avatarWrapper}>
             <TouchableOpacity onPress={pickImage} accessibilityRole="button">
-              <UserAvatar
-                avatar={editAvatarValue}
-                name={editName.trim() || user?.name}
-                seed={user?.id ?? editName}
-                size={80}
-                style={styles.avatarFrame}
-              />
-              <View style={styles.cameraBadge}>
-                <CameraIcon width={14} height={14} />
+              {!editAvatarValue && !editName.trim() ? (
+                <View style={[styles.avatarPlaceholder, { backgroundColor: avatarColor }]}>
+                  <ProfileIcon width={52} height={52} />
+                </View>
+              ) : (
+                <UserAvatar
+                  avatar={editAvatarValue}
+                  name={editName.trim() || user?.name}
+                  seed={user?.id ?? editName}
+                  size={120}
+                  style={styles.avatarFrame}
+                />
+              )}
+              <View style={styles.cameraBadgeShadow}>
+                <BlurView style={styles.cameraBadge} intensity={15} tint="light">
+                  <CameraIcon width={20} height={20} color="#707070" />
+                </BlurView>
               </View>
             </TouchableOpacity>
             {editAvatarValue && (
@@ -157,7 +167,7 @@ const EditProfileScreen = () => {
                 accessibilityRole="button"
                 accessibilityLabel="Remove photo"
               >
-                <CloseIcon width={13} height={13} color="#FFFFFF" />
+                <CloseIcon width={16} height={16} color="#FFFFFF" />
               </TouchableOpacity>
             )}
           </View>
@@ -206,34 +216,45 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 100,
+    marginBottom: 40,
   },
   avatarWrapper: {
     position: "relative",
     marginBottom: 24,
   },
   avatarFrame: {
-    width: 80,
-    height: 80,
-    borderRadius: 80,
-    borderWidth: 2,
-    borderColor: "#E6E6E6",
+    width: 120,
+    height: 120,
+    borderRadius: 60,
   },
-  cameraBadge: {
+  avatarPlaceholder: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cameraBadgeShadow: {
     position: "absolute",
     bottom: 4,
     right: -2,
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: "white",
-    justifyContent: "center",
-    alignItems: "center",
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 3,
+  },
+  cameraBadge: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(255,255,255,0.6)",
+    overflow: "hidden",
+    justifyContent: "center",
+    alignItems: "center",
   },
   removeBadge: {
     position: "absolute",

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -1387,13 +1387,9 @@ const EventDetailsScreenContent = ({
             accessibilityRole="button"
             onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); navigation.goBack(); }}
             hitSlop={12}
-            style={[
-              styles.overlayCloseButton,
-              styles.overlayCloseButtonFixed,
-              { top: insets.top + 10 },
-            ]}
+            style={[styles.backButton, { top: insets.top + 10 }]}
           >
-            <CloseIcon width={24} height={24} color={colors.buttonText} />
+            <ChevronLeftIcon width={24} height={24} color={colors.buttonText} />
           </Pressable>
         )}
         <ScrollView
@@ -1405,12 +1401,7 @@ const EventDetailsScreenContent = ({
           <View
             style={[
               styles.heroContainer,
-              readOnly
-                ? {
-                    paddingTop: screenHeight * 0.065,
-                    paddingBottom: screenHeight * 0.039,
-                  }
-                : { height: 320 + insets.top, paddingTop: insets.top + 10 },
+              { height: 320 + insets.top, paddingTop: insets.top + 10 },
             ]}
           >
             <Image
@@ -1425,10 +1416,7 @@ const EventDetailsScreenContent = ({
 
             {/* Elevated Image Card */}
             <View
-              style={[
-                styles.imageCardContainer,
-                readOnly && styles.imageCardContainerOverlay,
-              ]}
+              style={styles.imageCardContainer}
             >
               <Image
                 source={{ uri: event.imageUri }}
@@ -2669,7 +2657,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.sm,
-    paddingVertical: 6,
+    paddingBottom: 12,
   },
   memberName: {
     flex: 1,

--- a/src/screens/PastEventsScreen.tsx
+++ b/src/screens/PastEventsScreen.tsx
@@ -242,7 +242,9 @@ const PastEventsScreen = () => {
 };
 
 const styles = StyleSheet.create({
-  listContent: {},
+  listContent: {
+    paddingTop: 24,
+  },
   sectionHeader: {
     fontSize: 15,
     color: '#808080',


### PR DESCRIPTION
**Made the event detail view in Past Events look and behave identically to the regular Event Details screen, and fixed a few spacing inconsistencies along the way**

---

**Past Events → Event Detail:**
- Tapping a past event now navigates to the same EventDetails screen with a back chevron (instead of an X close button) in the top left, matching the regular event details navigation
- Fixed the hero section (blurred background + cover image card) to use the same fixed height and layout as regular event details, previously it was using a different height calculation that made the image look wrong
- Cover image card is now the same size (60% width) as regular event details
  
**Spacing fixes in Event Details:**
- Fixed the gap between the Members tab and the first member row — it was 22px due to extra padding on each member item, now consistently 16px matching the Requests tab 
- This fix applies to both the regular event details (Accepted tab) and the past events member list

---

**Before**

<img width="585" height="1266" alt="IMG_9750" src="https://github.com/user-attachments/assets/a0ed91f3-6c33-442d-9a95-a24e73e75770" />
<img width="585" height="1266" alt="IMG_9751" src="https://github.com/user-attachments/assets/3f196f34-4d87-4c3b-91df-fd8dc4c50aca" />


---

**After**

<img width="585" height="1266" alt="IMG_9748" src="https://github.com/user-attachments/assets/b2ab6f56-cc6f-4eb6-a50b-7a34580454f4" />
<img width="585" height="1266" alt="IMG_9749" src="https://github.com/user-attachments/assets/789c3218-a6f3-4643-869d-5f546859ec10" />

