### PR TITLE
fix: use bullet points instead of arrow icons

### DIFF
--- a/assets/help/reply.svg
+++ b/assets/help/reply.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.625 6.25L15 10.625L10.625 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M1 1V7.125C1 8.05329 1.36875 8.94351 2.02512 9.59985C2.6815 10.2563 3.57174 10.625 4.5 10.625H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/screens/HelpFeedbackScreen.tsx
+++ b/src/screens/HelpFeedbackScreen.tsx
@@ -7,7 +7,6 @@ import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import HelpForm from '@components/help/HelpForm';
 import { AppText } from '@components/ui';
-import ReplyIcon from '@assets/help/reply.svg';
 import { API_BASE_URL } from '@api/config';
 import { useAuth, type ApiError } from '@context/AuthContext';
 import { colors, typography } from '@theme/index';
@@ -89,7 +88,9 @@ const HelpFeedbackScreen = () => {
           <View style={styles.bulletList}>
             {FEEDBACK_BULLETS.map((item) => (
               <View key={item} style={styles.bulletRow}>
-                <ReplyIcon width={16} height={16} />
+                <AppText variant="body" style={styles.bulletMark}>
+                  {'•'}
+                </AppText>
                 <AppText variant="body" style={styles.bulletText}>
                   {item}
                 </AppText>
@@ -135,12 +136,17 @@ const styles = StyleSheet.create({
   },
   bulletList: {
     marginTop: 12,
-    gap: 12,
+    gap: 6,
   },
   bulletRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 10,
+    gap: 6,
+  },
+  bulletMark: {
+    color: '#828282',
+    fontSize: 15,
+    lineHeight: 22,
   },
   bulletText: {
     flex: 1,

--- a/src/screens/PrivacyPolicyScreen.tsx
+++ b/src/screens/PrivacyPolicyScreen.tsx
@@ -3,7 +3,6 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import ReplyIcon from '@assets/help/reply.svg';
 import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import { RootStackParamList } from '@navigation/types';
@@ -235,7 +234,7 @@ const PolicyBullets = ({ items }: { items: string[] }) => (
         key={`${item}-${index}`}
         style={[styles.bulletRow, index === items.length - 1 && styles.lastListRow]}
       >
-        <ReplyIcon width={16} height={16} color="#828282" style={styles.bulletMark} />
+        <Text style={styles.bulletMark}>{'•'}</Text>
         <Text style={styles.bulletText}>
           <InlineText text={item} />
         </Text>
@@ -422,8 +421,11 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   bulletMark: {
-    marginRight: 14,
-    marginTop: 3,
+    color: '#828282',
+    fontFamily: typography.fontFamilyRegular,
+    fontSize: 15,
+    lineHeight: 22,
+    marginRight: 10,
   },
   bulletText: {
     color: colors.text,


### PR DESCRIPTION
### Replaces the arrow icon (↳) used as a bullet marker in the Feedback and Privacy Policy screens with simple round bullet points (•), and cleans up spacing


**Changes**

- Feedback screen – The list under "Got ideas or thoughts?" now uses round bullet points instead of arrow icons. Tightened the gap between the bullet and its text, and reduced the vertical spacing between list items so it matches the Privacy Policy list.
- Privacy Policy screen – All bulleted lists now use round bullet points instead of arrow icons. Tightened the gap between the bullet and its text. The bullets keep the same gray color (#828282) the arrows had.
- No behavior changes – purely visual. No new screens, data, or logic.

**Deletes**

- Removed the now-unused arrow icon asset (assets/help/reply.svg), since nothing references it anymore.


---

**After**

<img width="585" height="1266" alt="IMG_0276" src="https://github.com/user-attachments/assets/afc1d9eb-1fd4-4479-bbf5-dfa379278b90" />
<img width="585" height="1266" alt="IMG_0277" src="https://github.com/user-attachments/assets/10cea681-a37d-4600-98a4-8abd46f51e53" />
<img width="585" height="1266" alt="IMG_0278" src="https://github.com/user-attachments/assets/5ba33d9c-24ed-4701-bfa5-8726ccf6cf38" />