### PR TITLE
Fix/backbtn align profile subpage

### DIFF
--- a/assets/help/reply.svg
+++ b/assets/help/reply.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.625 6.25L15 10.625L10.625 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M1 1V7.125C1 8.05329 1.36875 8.94351 2.02512 9.59985C2.6815 10.2563 3.57174 10.625 4.5 10.625H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/components/ScreenHeader.tsx
+++ b/src/components/ScreenHeader.tsx
@@ -30,11 +30,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     height: layout.headerHeight,
-    marginLeft: -8,
   },
   backButton: {
     width: layout.headerHeight,
     height: layout.headerHeight,
+    // Pull the button left so the chevron's tip (inset inside its icon)
+    // optically aligns with the page text's left margin, not the icon box.
+    // Kept on the button (not the header) so the centered title stays
+    // centered on the screen.
+    marginLeft: -18,
   },
   titleContainer: {
     position: 'absolute',
@@ -47,8 +51,8 @@ const styles = StyleSheet.create({
   },
   title: {
     textAlign: 'center',
-    fontSize: 18,
-    lineHeight: 24,
+    fontSize: 17,
+    lineHeight: 22,
     fontFamily: typography.fontFamilyMedium,
     color: colors.text,
     letterSpacing: -0.4,

--- a/src/screens/HelpFeedbackScreen.tsx
+++ b/src/screens/HelpFeedbackScreen.tsx
@@ -7,7 +7,6 @@ import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import HelpForm from '@components/help/HelpForm';
 import { AppText } from '@components/ui';
-import ReplyIcon from '@assets/help/reply.svg';
 import { API_BASE_URL } from '@api/config';
 import { useAuth, type ApiError } from '@context/AuthContext';
 import { colors, typography } from '@theme/index';
@@ -89,7 +88,9 @@ const HelpFeedbackScreen = () => {
           <View style={styles.bulletList}>
             {FEEDBACK_BULLETS.map((item) => (
               <View key={item} style={styles.bulletRow}>
-                <ReplyIcon width={16} height={16} />
+                <AppText variant="body" style={styles.bulletMark}>
+                  {'•'}
+                </AppText>
                 <AppText variant="body" style={styles.bulletText}>
                   {item}
                 </AppText>
@@ -135,12 +136,17 @@ const styles = StyleSheet.create({
   },
   bulletList: {
     marginTop: 12,
-    gap: 12,
+    gap: 6,
   },
   bulletRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 10,
+    gap: 6,
+  },
+  bulletMark: {
+    color: '#828282',
+    fontSize: 15,
+    lineHeight: 22,
   },
   bulletText: {
     flex: 1,

--- a/src/screens/PrivacyPolicyScreen.tsx
+++ b/src/screens/PrivacyPolicyScreen.tsx
@@ -3,7 +3,6 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import ReplyIcon from '@assets/help/reply.svg';
 import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import { RootStackParamList } from '@navigation/types';
@@ -235,7 +234,7 @@ const PolicyBullets = ({ items }: { items: string[] }) => (
         key={`${item}-${index}`}
         style={[styles.bulletRow, index === items.length - 1 && styles.lastListRow]}
       >
-        <ReplyIcon width={16} height={16} color="#828282" style={styles.bulletMark} />
+        <Text style={styles.bulletMark}>{'•'}</Text>
         <Text style={styles.bulletText}>
           <InlineText text={item} />
         </Text>
@@ -422,8 +421,11 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   bulletMark: {
-    marginRight: 14,
-    marginTop: 3,
+    color: '#828282',
+    fontFamily: typography.fontFamilyRegular,
+    fontSize: 15,
+    lineHeight: 22,
+    marginRight: 10,
   },
   bulletText: {
     color: colors.text,


### PR DESCRIPTION
### Fix alignment and sizing of the shared screen header


**Changes**

- Shared screen header (back button + centered title, used on Edit Profile, Past Events, Privacy Policy, Help, Contact us, FAQ, and Feedback):
- The back arrow's tip now lines up with the left edge of the page text, instead of being slightly indented.
- The centered title now sits at the true center of the screen (it was previously about 4px off to the left).
- The title text size was reduced from 18pt to 17pt.

---

**After**

<img width="585" height="1266" alt="IMG_0281 2" src="https://github.com/user-attachments/assets/e4aebf53-ad36-442d-a1d0-bc7f1912deeb" />
<img width="585" height="1266" alt="IMG_0282 2" src="https://github.com/user-attachments/assets/939a23c4-5478-4a19-a1b7-1b02d9820ca1" />