### PR TITLE
polish:line separator across app

### DIFF
--- a/src/components/events/EventMemberRow.tsx
+++ b/src/components/events/EventMemberRow.tsx
@@ -66,12 +66,24 @@ const EventMemberRow: React.FC<EventMemberRowProps> = ({
   );
 };
 
+/**
+ * Divider between member rows. Tighter than the request-row separator since
+ * member rows are compact; the row's own paddingBottom provides the top gap.
+ */
+export const EventMemberRowSeparator: React.FC = () => <View style={styles.separator} />;
+
 const styles = StyleSheet.create({
   memberItem: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
     paddingBottom: 12,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginLeft: 48, // avatar (40) + gap (8)
+    marginBottom: 12,
   },
   memberName: {
     flex: 1,

--- a/src/components/events/index.ts
+++ b/src/components/events/index.ts
@@ -1,5 +1,5 @@
 export { default as EventListPage } from './EventListPage';
-export { default as EventMemberRow } from './EventMemberRow';
+export { default as EventMemberRow, EventMemberRowSeparator } from './EventMemberRow';
 export type { EventMemberRowProps } from './EventMemberRow';
 export { default as EventRequestRow, EventRequestRowSeparator } from './EventRequestRow';
 export type { EventRequestRowProps } from './EventRequestRow';

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -273,7 +273,11 @@ const JoinRequestsScreen = () => {
         style={({ pressed }) => [styles.requestRow1to1, pressed && styles.requestRowPressed]}
         onPress={() => handleRequesterPress(item)}
       >
-        {hasUnread && <UnreadDot style={styles.unreadDot1to1} />}
+        {hasUnread && (
+          <View style={styles.unreadDot1to1Wrap}>
+            <UnreadDot />
+          </View>
+        )}
         <UserAvatar
           avatar={item.requester.avatar}
           name={item.requester.name}
@@ -374,6 +378,11 @@ const JoinRequestsScreen = () => {
           ItemSeparatorComponent={() => (
             <View style={is1to1Mode ? styles.separator1to1 : styles.separator} />
           )}
+          ListFooterComponent={
+            displayRequests.length > 0 ? (
+              <View style={is1to1Mode ? styles.separator1to1 : styles.separator} />
+            ) : null
+          }
           contentContainerStyle={
             displayRequests.length === 0
               ? styles.listEmptyContent
@@ -415,10 +424,12 @@ const styles = StyleSheet.create({
   separator: {
     height: 1,
     backgroundColor: colors.border,
+    marginLeft: 48, // avatar (40) + gap (8) — align after the avatar
   },
   separator1to1: {
     height: 1,
     backgroundColor: colors.border,
+    marginLeft: 64, // avatar (40) + gap (8) + list marginLeft offset (16)
   },
   // Group mode request item styles
   requestItem: {
@@ -514,11 +525,12 @@ const styles = StyleSheet.create({
     color: colors.text,
     fontFamily: typography.fontFamilyMedium,
   },
-  unreadDot1to1: {
+  unreadDot1to1Wrap: {
     position: 'absolute',
     left: 5,
-    top: '50%',
-    marginTop: -4,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
   },
 });
 

--- a/src/screens/event-details/EventDetailsMembers.tsx
+++ b/src/screens/event-details/EventDetailsMembers.tsx
@@ -1,7 +1,7 @@
 import { ActivityIndicator, Text, View } from 'react-native';
 
 import EmptyState from '@components/EmptyState';
-import { EventMemberRow } from '@components/events';
+import { EventMemberRow, EventMemberRowSeparator } from '@components/events';
 import { SlidingTabs } from '@components/ui';
 import { colors } from '@theme/index';
 
@@ -66,17 +66,19 @@ const EventDetailsMembers = (props: EventDetailsMembersProps) => {
               style={{ marginTop: 32 }}
             />
           ) : (
-            members.map((member) => (
-              <EventMemberRow
-                key={member.id}
-                member={member}
-                trailingLabel={member.id === currentUserId && isOwner ? 'Host' : undefined}
-                onMenuPress={
-                  isOwner && member.id !== currentUserId
-                    ? () => onOpenMemberMenu(member)
-                    : undefined
-                }
-              />
+            members.map((member, index) => (
+              <View key={member.id}>
+                <EventMemberRow
+                  member={member}
+                  trailingLabel={member.id === currentUserId && isOwner ? 'Host' : undefined}
+                  onMenuPress={
+                    isOwner && member.id !== currentUserId
+                      ? () => onOpenMemberMenu(member)
+                      : undefined
+                  }
+                />
+                {index < members.length - 1 && <EventMemberRowSeparator />}
+              </View>
             ))
           )}
         </View>
@@ -110,12 +112,11 @@ const EventDetailsMembers = (props: EventDetailsMembersProps) => {
             style={{ marginTop: 32 }}
           />
         ) : (
-          members.map((member) => (
-            <EventMemberRow
-              key={member.id}
-              member={member}
-              trailingLabel={member.id === hostId ? 'Host' : undefined}
-            />
+          members.map((member, index) => (
+            <View key={member.id}>
+              <EventMemberRow member={member} trailingLabel={member.id === hostId ? 'Host' : undefined} />
+              {index < members.length - 1 && <EventMemberRowSeparator />}
+            </View>
           ))
         )}
       </View>

--- a/src/screens/event-details/HostRequestTabs.tsx
+++ b/src/screens/event-details/HostRequestTabs.tsx
@@ -5,7 +5,12 @@ import { View } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import EmptyState from '@components/EmptyState';
-import { EventMemberRow, EventRequestRow, EventRequestRowSeparator } from '@components/events';
+import {
+  EventMemberRow,
+  EventMemberRowSeparator,
+  EventRequestRow,
+  EventRequestRowSeparator,
+} from '@components/events';
 import { SlidingTabs } from '@components/ui';
 import { ChatJoinRequest } from '@context/ChatContext';
 
@@ -161,13 +166,15 @@ const HostRequestTabs = ({
                   style={{ marginTop: 32 }}
                 />
               ) : (
-                acceptedRequests.map((request) => (
-                  <EventMemberRow
-                    key={request.id}
-                    member={request.requester}
-                    onPress={() => onRequesterPress(request)}
-                    onMenuPress={() => onOpenMemberMenu(request.requester)}
-                  />
+                acceptedRequests.map((request, index) => (
+                  <View key={request.id}>
+                    <EventMemberRow
+                      member={request.requester}
+                      onPress={() => onRequesterPress(request)}
+                      onMenuPress={() => onOpenMemberMenu(request.requester)}
+                    />
+                    {index < acceptedRequests.length - 1 && <EventMemberRowSeparator />}
+                  </View>
                 ))
               )
             ) : confirmedMembers.length === 0 ? (
@@ -180,12 +187,11 @@ const HostRequestTabs = ({
                 style={{ marginTop: 32 }}
               />
             ) : (
-              confirmedMembers.map((member) => (
-                <EventMemberRow
-                  key={member.id}
-                  member={member}
-                  onMenuPress={() => onOpenMemberMenu(member)}
-                />
+              confirmedMembers.map((member, index) => (
+                <View key={member.id}>
+                  <EventMemberRow member={member} onMenuPress={() => onOpenMemberMenu(member)} />
+                  {index < confirmedMembers.length - 1 && <EventMemberRowSeparator />}
+                </View>
               ))
             )}
           </View>


### PR DESCRIPTION
### Consistent row separators in accepted, members, joinrequest screen

Adds divider lines between rows in the accepted/members lists so they match the Requests tab and the rest of the app, plus two small related fixes.

**Changed**
  - **Event Details (host) — Accepted (1:1) and Members (group) tabs**: now show a divider between each row (previously had none).
  - **Event Details overlay & read-only Members lists**: same dividers added.
  - **Join Requests screen**:
    - Separators are now indented to line up after the avatar (matching the other lists) instead of running full width.
    - Added a divider after the last row too, so every row has an underline — consistent with the Chat list.
    - Fixed the unread blue dot so it's vertically centered in each row (it was sitting near the top).
    
### Added
  - A shared `EventMemberRowSeparator` — a thin, avatar-indented divider for member rows (tighter spacing than the request-row separator, since member rows are compact). Exported from `@components/events`.
  
  
  ---
  
  **Before / After**
  
<img width="2786" height="3114" alt="image" src="https://github.com/user-attachments/assets/10a11622-4125-475e-8ff5-2efa4d6ddf9a" />
<img width="2786" height="3114" alt="image" src="https://github.com/user-attachments/assets/0c58c28a-d5ef-431b-b93a-db526ea46cd9" />
<img width="2786" height="3114" alt="image" src="https://github.com/user-attachments/assets/5d2dc2df-948b-4da7-bb59-b59837e2ffb0" />
<img width="2786" height="3114" alt="image" src="https://github.com/user-attachments/assets/917e9c82-322d-40b4-8e47-96c8e6b51d19" />
<img width="2786" height="3114" alt="image" src="https://github.com/user-attachments/assets/dd49b076-053e-46e2-b502-98f7d1958290" />


  