### PR TITLE
feat: add missing toast in few screen

### DIFF
--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -52,6 +52,7 @@ export type RootTabParamList = {
         showEventDeletedBadge?: boolean;
         showEventLeftBadge?: boolean;
         showNoAccessModal?: boolean;
+        showWelcomeBadge?: boolean;
       }
     | undefined;
   MyEvents:
@@ -61,6 +62,6 @@ export type RootTabParamList = {
       }
     | undefined;
   Create: { editEventId?: string | null };
-  Profile: undefined;
+  Profile: { showProfileUpdatedBadge?: boolean } | undefined;
   Messages: undefined;
 };

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -114,7 +114,10 @@ const EditProfileScreen = () => {
         age: user.age ?? 18,
         avatar: avatarValue,
       });
-      navigation.goBack();
+      navigation.navigate('Main', {
+        screen: 'Profile',
+        params: { showProfileUpdatedBadge: true },
+      });
     } catch (error) {
       const status = error instanceof Error ? (error as ApiError).status : undefined;
       if (status === 401) return;

--- a/src/screens/HelpContactScreen.tsx
+++ b/src/screens/HelpContactScreen.tsx
@@ -3,6 +3,7 @@ import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
+import EventActionBadge from '@components/EventActionBadge';
 import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import HelpForm from '@components/help/HelpForm';
@@ -24,6 +25,7 @@ const HelpContactScreen = () => {
   const [replyEmail, setReplyEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [checkedOptions, setCheckedOptions] = useState<string[]>([]);
+  const [showSentBadge, setShowSentBadge] = useState(false);
 
   const toggleOption = useCallback((value: string) => {
     setCheckedOptions((current) =>
@@ -76,7 +78,7 @@ const HelpContactScreen = () => {
         wants_reply: wantsReply,
         reply_email: wantsReply ? email : undefined,
       });
-      Alert.alert('Message sent', 'Thanks. We will get back to you as soon as we can.');
+      setShowSentBadge(true);
       setContactMessage('');
       setReplyEmail('');
       setCheckedOptions([]);
@@ -122,6 +124,11 @@ const HelpContactScreen = () => {
           />
         </View>
       </ScrollView>
+      <EventActionBadge
+        visible={showSentBadge}
+        label="Message sent"
+        onHidden={() => setShowSentBadge(false)}
+      />
     </ScreenContainer>
   );
 };

--- a/src/screens/HelpFeedbackScreen.tsx
+++ b/src/screens/HelpFeedbackScreen.tsx
@@ -3,6 +3,7 @@ import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
+import EventActionBadge from '@components/EventActionBadge';
 import ScreenContainer from '@components/ScreenContainer';
 import ScreenHeader from '@components/ScreenHeader';
 import HelpForm from '@components/help/HelpForm';
@@ -24,6 +25,7 @@ const HelpFeedbackScreen = () => {
   const { authFetch } = useAuth();
   const [feedbackMessage, setFeedbackMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSentBadge, setShowSentBadge] = useState(false);
 
   const submitHelpRequest = useCallback(
     async (body: Record<string, unknown>) => {
@@ -57,7 +59,7 @@ const HelpFeedbackScreen = () => {
     setIsSubmitting(true);
     try {
       await submitHelpRequest({ type: 'feedback', message });
-      Alert.alert('Feedback sent', 'Thanks for helping us improve Who else is free.');
+      setShowSentBadge(true);
       setFeedbackMessage('');
     } catch (error) {
       Alert.alert(
@@ -107,6 +109,11 @@ const HelpFeedbackScreen = () => {
           />
         </View>
       </ScrollView>
+      <EventActionBadge
+        visible={showSentBadge}
+        label="Feedback sent"
+        onHidden={() => setShowSentBadge(false)}
+      />
     </ScreenContainer>
   );
 };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -93,6 +93,13 @@ const HomeScreen = () => {
   const [showEventDeletedBadge, setShowEventDeletedBadge] = useState(false);
   const [showEventLeftBadge, setShowEventLeftBadge] = useState(false);
   const [showNoAccessModal, setShowNoAccessModal] = useState(false);
+  const [showWelcomeBadge, setShowWelcomeBadge] = useState(false);
+
+  useEffect(() => {
+    if (!route.params?.showWelcomeBadge) return;
+    const t = setTimeout(() => setShowWelcomeBadge(true), 350);
+    return () => clearTimeout(t);
+  }, [route.params?.showWelcomeBadge]);
 
   useEffect(() => {
     if (!route.params?.showEventReportedBadge) return;
@@ -360,6 +367,14 @@ const HomeScreen = () => {
           </View>
         </View>
       </View>
+      <EventActionBadge
+        visible={showWelcomeBadge}
+        label="Welcome to WEIF"
+        onHidden={() => {
+          setShowWelcomeBadge(false);
+          navigation.setParams({ showWelcomeBadge: false });
+        }}
+      />
       <EventActionBadge
         visible={showReportedBadge}
         label="Event Reported, Admins are looking into it"

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -186,7 +186,12 @@ const OnboardingScreen = () => {
       });
       navigation.reset({
         index: 0,
-        routes: [{ name: 'Main' }],
+        routes: [
+          {
+            name: 'Main',
+            params: { screen: 'Events', params: { showWelcomeBadge: true } },
+          },
+        ],
       });
     } catch (error) {
       logger.warn('Profile update failed', error);

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -3,10 +3,16 @@ import { LinearGradient } from 'expo-linear-gradient';
 import ScalePressable from '@components/ScalePressable';
 import BellIcon from '@assets/notification/bell.svg';
 
-import { useCallback, useMemo, useState } from 'react';
-import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  CompositeNavigationProp,
+  RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { StackNavigationProp } from '@react-navigation/stack';
+import EventActionBadge from '@components/EventActionBadge';
 import ScreenContainer from '@components/ScreenContainer';
 import ChevronRightIcon from '@assets/ui/chevron-right.svg';
 import { UnreadDot, IconButton } from '@components/ui';
@@ -75,9 +81,17 @@ const ProfileScreen = () => {
   const { conversations } = useChat();
   const { unreadCount } = useNotifications();
   const navigation = useNavigation<ProfileNavigation>();
+  const route = useRoute<RouteProp<RootTabParamList, 'Profile'>>();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [showProfileUpdatedBadge, setShowProfileUpdatedBadge] = useState(false);
+
+  useEffect(() => {
+    if (route.params?.showProfileUpdatedBadge) {
+      setShowProfileUpdatedBadge(true);
+    }
+  }, [route.params?.showProfileUpdatedBadge]);
 
   // Calculate stats
   const hostedCount = userEvents.length;
@@ -340,6 +354,14 @@ const ProfileScreen = () => {
         onCancel={handleDeleteCancel}
         isConfirmLoading={isDeletingAccount}
         errorMessage={deleteError}
+      />
+      <EventActionBadge
+        visible={showProfileUpdatedBadge}
+        label="Profile updated"
+        onHidden={() => {
+          setShowProfileUpdatedBadge(false);
+          navigation.setParams({ showProfileUpdatedBadge: false });
+        }}
       />
     </ScreenContainer>
   );

--- a/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
@@ -455,25 +455,23 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(getByTestId('going-row')).toBeTruthy();
     });
 
-    it('shows "Event details updated" badge after transition when route param is set', () => {
+    it('shows "Event details updated" badge after a short delay when route param is set', () => {
+      jest.useFakeTimers();
       const routeSpy = jest
         .spyOn(require('@react-navigation/native'), 'useRoute')
         .mockReturnValue(createMockRoute('1', 'MyEvents', true));
 
       const { getByText, queryByText } = render(<EventDetailsScreen />);
       expect(queryByText('Event details updated')).toBeNull();
-      expect(mockNavigation.addListener).toHaveBeenCalledWith(
-        'transitionEnd',
-        expect.any(Function),
-      );
 
       act(() => {
-        mockNavigationListeners.transitionEnd?.();
+        jest.advanceTimersByTime(350);
       });
 
       expect(getByText('Event details updated')).toBeTruthy();
 
       routeSpy.mockRestore();
+      jest.useRealTimers();
     });
 
     it('opens chat when "Go to Chat" is pressed', () => {

--- a/src/screens/__tests__/OnboardingScreen.rendering.test.tsx
+++ b/src/screens/__tests__/OnboardingScreen.rendering.test.tsx
@@ -269,7 +269,12 @@ describe('OnboardingScreen Rendering', () => {
       await waitFor(() => {
         expect(mockReset).toHaveBeenCalledWith({
           index: 0,
-          routes: [{ name: 'Main' }],
+          routes: [
+            {
+              name: 'Main',
+              params: { screen: 'Events', params: { showWelcomeBadge: true } },
+            },
+          ],
         });
       });
     });

--- a/src/screens/event-details/useEventDetailsActions.ts
+++ b/src/screens/event-details/useEventDetailsActions.ts
@@ -93,11 +93,11 @@ export const useEventDetailsActions = ({
     if (!showEventUpdatedBadgeParam) {
       return;
     }
-    const unsubscribe = navigation.addListener('transitionEnd', () => {
-      setShowEventUpdatedBadge(true);
-      unsubscribe();
-    });
-    return unsubscribe;
+    // Delay so the badge appears after the pop-to-EventDetails transition
+    // settles. A prior `transitionEnd` listener missed the event because it
+    // attached after `popTo` had already fired it, so no toast showed.
+    const timer = setTimeout(() => setShowEventUpdatedBadge(true), 350);
+    return () => clearTimeout(timer);
   }, [showEventUpdatedBadgeParam]);
 
   const shouldShowInvitePrompt = showInvitePrompt && !isOwner;


### PR DESCRIPTION
### Add missing toast confirmations + fix event-updated toast

Adds system-feedback toasts for several actions that previously had no (or intrusive) confirmation, and fixes an existing toast that wasn't showing. All reuse the existing EventActionBadge component — no new toast infra.

### Added 
  - **"Welcome to WEIF"** — shown on the Explore (Home) page right after a user finishes onboarding and lands there.
  - **"Message sent"** — shown after sending a message on the Contact us page.
  - **"Feedback sent"** — shown after sending on the Feedback page.
  - **"Profile updated"** — shown on the Profile page after saving edits in Edit Profile.

### Changed
  - **Contact us / Feedback**: replaced the native pop-up alert on success with the less-intrusive toast.
  - **Edit Profile**: on save, now returns to the Profile tab carrying a flag so the "Profile updated" toast shows there (it can't show on the edit screen since that closes immediately).
  - **Onboarding**: on completion, routes to the Explore tab with a flag that triggers the welcome toast.
  - **Fixed "Event details updated" toast**: after editing an event and tapping "Update Event", the toast wasn't appearing. It relied on a navigation transition event that was missed when returning to Event Details; switched it to the same short-delay mechanism the other toasts use, so it now shows reliably.
  - Updated two tests to match the new toast triggers.

---

**After**

<img width="585" height="1266" alt="IMG_0445" src="https://github.com/user-attachments/assets/c8b2eb55-5964-4414-972f-d3b6bd7da57d" />
<img width="585" height="1266" alt="IMG_0446" src="https://github.com/user-attachments/assets/0be03dc8-db9f-450f-8c83-a05ab1512164" />
<img width="585" height="1266" alt="IMG_0448" src="https://github.com/user-attachments/assets/4b644f59-8f6c-4284-8c9b-f795b207e698" />
<img width="585" height="1266" alt="IMG_0449" src="https://github.com/user-attachments/assets/90a71aa0-c5f1-478b-af95-b3f356e00339" />
