### PR TITLE
fix: spacing b/w hosting and going in event details

### DIFF
--- a/src/screens/event-details/EventDetailsInfo.tsx
+++ b/src/screens/event-details/EventDetailsInfo.tsx
@@ -69,31 +69,35 @@ const EventDetailsInfo = ({
 
   return (
     <>
-      <Text style={styles.title}>{title}</Text>
-      <Text style={styles.hostedBy}>{hostLine}</Text>
-      {!readOnly && isSingleEvent && (
-        <Text style={styles.goingLabel} testID="going-count-label">
-          1:1
-        </Text>
-      )}
-      {!readOnly && !isSingleEvent && (
-        <View style={styles.goingRow} testID="going-row">
-          <View style={styles.goingAvatarStack}>
-            {goingParticipants.slice(0, 4).map((participant, index) => (
-              <View
-                key={`${participant.id}-${index}`}
-                style={[styles.goingAvatarItem, index > 0 && styles.goingAvatarOverlap]}
-                testID={`going-avatar-${index}`}
-              >
-                {renderAvatar(participant, 28)}
-              </View>
-            ))}
-          </View>
-          <Text style={styles.goingLabel} testID="going-count-label">
-            {`${goingCount} Going`}
+      {/* Header block has no gap; each row's vertical spacing is its own
+          marginTop (styles.hostedBy / styles.goingRow / styles.goingLabelStandalone). */}
+      <View style={styles.headerBlock}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.hostedBy}>{hostLine}</Text>
+        {!readOnly && isSingleEvent && (
+          <Text style={[styles.goingLabel, styles.goingLabelStandalone]} testID="going-count-label">
+            1:1
           </Text>
-        </View>
-      )}
+        )}
+        {!readOnly && !isSingleEvent && (
+          <View style={styles.goingRow} testID="going-row">
+            <View style={styles.goingAvatarStack}>
+              {goingParticipants.slice(0, 4).map((participant, index) => (
+                <View
+                  key={`${participant.id}-${index}`}
+                  style={[styles.goingAvatarItem, index > 0 && styles.goingAvatarOverlap]}
+                  testID={`going-avatar-${index}`}
+                >
+                  {renderAvatar(participant, 28)}
+                </View>
+              ))}
+            </View>
+            <Text style={styles.goingLabel} testID="going-count-label">
+              {`${goingCount} Going`}
+            </Text>
+          </View>
+        )}
+      </View>
 
       <View style={[styles.divider, { marginTop: 12, marginBottom: 12 }]} />
 

--- a/src/screens/event-details/EventDetailsScreen.styles.ts
+++ b/src/screens/event-details/EventDetailsScreen.styles.ts
@@ -143,7 +143,13 @@ const styles = StyleSheet.create({
     lineHeight: typography.titleLineHeight,
     letterSpacing: typography.letterSpacing,
   },
+  // Groups title + host + going with NO gap, so each gap below is exactly the
+  // child's marginTop (no hidden card gap). Tune the two gaps via:
+  //   Gap A (title → host):   hostedBy.marginTop
+  //   Gap B (host → going):   goingRow.marginTop / goingLabelStandalone.marginTop
+  headerBlock: {},
   hostedBy: {
+    marginTop: spacing.xs, // Gap A: title → "Hosted by"
     fontSize: 16,
     fontFamily: typography.fontFamilyRegular,
     color: colors.subText,
@@ -151,9 +157,13 @@ const styles = StyleSheet.create({
     letterSpacing: typography.letterSpacing,
   },
   goingRow: {
+    marginTop: spacing.sm, // Gap B: host → "N Going" (group)
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
+  },
+  goingLabelStandalone: {
+    marginTop: spacing.sm, // Gap B: host → "1:1" (single event)
   },
   goingAvatarStack: {
     flexDirection: 'row',


### PR DESCRIPTION
### Consistent spacing between host line and "Going" row in event details

**Description**
On the Event Details header, the vertical gap between "Hosted by …" and the "N Going" row didn't match the gap between the event title and "Hosted by", so the spacing looked uneven. The header previously relied on a single uniform gap applied to every element in the card. Because the "Going" row is taller (it has a 28px avatar), that uniform gap read larger under the host line than under the title — making the two gaps look inconsistent.

  ### Changed
  - Grouped the title, host line, and "Going" row into a container with no shared gap, so each gap is now set by an explicit per-row `marginTop` instead of the card's uniform gap. This makes the title→host and host→going gaps independently controllable and visually consistent.
  - Tuned those two margins so the spacing looks even.
  
  ### Added
  - Nothing user-facing (an internal wrapper + a couple of margin styles to make the spacing explicit).

---

**Before vs After (group)**

<img width="2696" height="3012" alt="image" src="https://github.com/user-attachments/assets/1b359d18-0095-4a5d-a908-64c35f911f0f" />


**Before vs After (1:1)**
<img width="2696" height="3012" alt="image" src="https://github.com/user-attachments/assets/f8c0f47b-cb72-41d9-b5f1-ad4037639846" />
