### PR TITLE
polish: description in event details

### DIFF
--- a/assets/event-details/description.svg
+++ b/assets/event-details/description.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.5 5H16.5" stroke="#707070" stroke-width="1.7" stroke-linecap="round"/>
+<path d="M3.5 10H16.5" stroke="#707070" stroke-width="1.7" stroke-linecap="round"/>
+<path d="M3.5 15H12.5" stroke="#707070" stroke-width="1.7" stroke-linecap="round"/>
+</svg>

--- a/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
@@ -1238,7 +1238,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
 
       fireMeasurementLayouts(getByTestId);
 
-      expect(getByText('...See more')).toBeTruthy();
+      expect(getByText('See more')).toBeTruthy();
     });
 
     it('expands description when See more is pressed', () => {
@@ -1246,23 +1246,23 @@ describe('EventDetailsScreen Rendering Tests', () => {
 
       fireMeasurementLayouts(getByTestId);
 
-      fireEvent.press(getByText('...See more'));
+      fireEvent.press(getByText('See more'));
 
       // After expansion, "See more" should not be visible
-      expect(queryByText('...See more')).toBeNull();
-      expect(getByText('Show less')).toBeTruthy();
+      expect(queryByText('See more')).toBeNull();
+      expect(getByText('See less')).toBeTruthy();
     });
 
-    it('collapses description when Show less is pressed', () => {
+    it('collapses description when See less is pressed', () => {
       const { getByText, queryByText, getByTestId } = render(<EventDetailsScreen />);
 
       fireMeasurementLayouts(getByTestId);
 
-      fireEvent.press(getByText('...See more'));
-      fireEvent.press(getByText('Show less'));
+      fireEvent.press(getByText('See more'));
+      fireEvent.press(getByText('See less'));
 
-      expect(queryByText('Show less')).toBeNull();
-      expect(getByText('...See more')).toBeTruthy();
+      expect(queryByText('See less')).toBeNull();
+      expect(getByText('See more')).toBeTruthy();
     });
 
     it('does not show toggle for short descriptions', () => {
@@ -1280,8 +1280,8 @@ describe('EventDetailsScreen Rendering Tests', () => {
         nativeEvent: { layout: { height: 22 } },
       });
 
-      expect(queryByText('...See more')).toBeNull();
-      expect(queryByText('Show less')).toBeNull();
+      expect(queryByText('See more')).toBeNull();
+      expect(queryByText('See less')).toBeNull();
     });
   });
 

--- a/src/screens/event-details/EventDetailsInfo.tsx
+++ b/src/screens/event-details/EventDetailsInfo.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 
 import { Text, View } from 'react-native';
 
+import DescriptionIcon from '@assets/event-details/description.svg';
 import PeopleIcon from '@assets/event-details/group-type.svg';
 import LocationIcon from '@assets/event-details/location.svg';
 import TimeIcon from '@assets/event-details/time.svg';
+import ScalePressable from '@components/ScalePressable';
 import UserAvatar from '@components/UserAvatar';
-import { triggerHaptic } from '@services/haptics';
 import { colors } from '@theme/index';
 
 import styles from './EventDetailsScreen.styles';
@@ -121,43 +122,50 @@ const EventDetailsInfo = ({
           </View>
           <Text style={styles.detailText}>{audienceLine}</Text>
         </View>
-      </View>
-
-      {!!description && (
-        <View style={{ marginTop: 6 }}>
-          <View style={styles.measureContainer}>
-            <Text
-              style={styles.description}
-              onLayout={(e) => setFullDescHeight(e.nativeEvent.layout.height)}
-              testID="description-full-measure"
-            >
-              {description}
-            </Text>
-            <Text
-              style={styles.description}
-              numberOfLines={2}
-              onLayout={(e) => setTruncatedDescHeight(e.nativeEvent.layout.height)}
-              testID="description-truncated-measure"
-            >
-              {description}
-            </Text>
+        {!!description && (
+          <View style={styles.descriptionRow}>
+            {/* Icon container height = description line-height, so with the row
+                top-aligned the icon centers on the FIRST line: it reads centered
+                on a single line and top-aligned once the text wraps. */}
+            <View style={styles.descriptionIconContainer}>
+              <DescriptionIcon width={20} height={20} color={colors.iconColor} />
+            </View>
+            <View style={styles.descriptionContent}>
+              <View style={styles.measureContainer}>
+                <Text
+                  style={styles.description}
+                  onLayout={(e) => setFullDescHeight(e.nativeEvent.layout.height)}
+                  testID="description-full-measure"
+                >
+                  {description}
+                </Text>
+                <Text
+                  style={styles.description}
+                  numberOfLines={2}
+                  onLayout={(e) => setTruncatedDescHeight(e.nativeEvent.layout.height)}
+                  testID="description-truncated-measure"
+                >
+                  {description}
+                </Text>
+              </View>
+              <Text style={styles.description} numberOfLines={descriptionExpanded ? undefined : 2}>
+                {description}
+              </Text>
+              {descriptionHasMore && (
+                <ScalePressable
+                  haptic="light"
+                  onPress={() => setDescriptionExpanded((prev) => !prev)}
+                  style={styles.seeMoreButton}
+                >
+                  <Text style={styles.seeMoreText}>
+                    {descriptionExpanded ? 'See less' : 'See more'}
+                  </Text>
+                </ScalePressable>
+              )}
+            </View>
           </View>
-          <Text style={styles.description} numberOfLines={descriptionExpanded ? undefined : 2}>
-            {description}
-          </Text>
-          {descriptionHasMore && (
-            <Text
-              style={styles.seeMoreText}
-              onPress={() => {
-                triggerHaptic('light');
-                setDescriptionExpanded((prev) => !prev);
-              }}
-            >
-              {descriptionExpanded ? 'Show less' : '...See more'}
-            </Text>
-          )}
-        </View>
-      )}
+        )}
+      </View>
     </>
   );
 };

--- a/src/screens/event-details/EventDetailsScreen.styles.ts
+++ b/src/screens/event-details/EventDetailsScreen.styles.ts
@@ -226,6 +226,21 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     letterSpacing: -0.4,
   },
+  descriptionRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start', // top-aligned so the icon can center on the first line
+    gap: 6,
+    paddingVertical: 4, // match the other detail rows' rhythm
+  },
+  descriptionIconContainer: {
+    width: 24,
+    height: 22, // = description line-height, centers the icon on the first line
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  descriptionContent: {
+    flex: 1,
+  },
   measureContainer: {
     position: 'absolute',
     top: -9999,
@@ -326,13 +341,16 @@ const styles = StyleSheet.create({
   },
 
   // See more text
+  seeMoreButton: {
+    alignSelf: 'flex-start', // hug the text so the press-scale is tight, not full-width
+    marginTop: 2,
+  },
   seeMoreText: {
     fontSize: 15,
     fontFamily: typography.fontFamilyMedium,
     color: colors.iconColor,
     lineHeight: 20,
     letterSpacing: -0.3,
-    marginTop: 2,
   },
 
   // Empty state text


### PR DESCRIPTION
### Give event description an icon and fold it into the Details section

**Description:**

Polishes how the event description is shown on the Event Details page so it reads as part of the Details list instead of a loose block, and cleans up the "See more" toggle.

**Added** 
- A **description icon** next to the description text (new `description.svg`), so the description matches the other detail rows (icon + text) — location, time, audience, description.
  
**Changed**
- The **description is now part of the Details section** (a row alongside location/time/audience) instead of a separate block below it.
- The description **icon aligns smartly**: it sits vertically centered when the text is a single line, and top-aligns with the first line once the text wraps to multiple lines.
- **Toggle labels** are now consistent: "…See more" → **"See more"** and "Show less" → **"See less"**.
- The **"See more" / "See less" toggle now has the standard press animation** (scales down/up on tap with a light haptic), matching buttons/tabs elsewhere, instead of a plain tappable text.
- Updated the description tests to match the new labels.

---

**Before**
<img width="585" height="1266" alt="IMG_0575" src="https://github.com/user-attachments/assets/d16283e3-6983-456d-abca-a90257b098d6" />


**After**
<img width="585" height="1266" alt="IMG_0574" src="https://github.com/user-attachments/assets/b934317b-3949-4f5f-94cb-5de5b1705f50" />
