### PR TITLE
polish: unify line-separator color, thickness, and spacing across the app

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -15,6 +15,7 @@ export interface NotificationRowProps {
   onPress: (notification: AppNotification) => void;
   nowMs: number;
   eventImageUri?: string;
+  isLast?: boolean;
 }
 
 /**
@@ -26,7 +27,13 @@ export interface NotificationRowProps {
  * Shows the event cover image when the notification has an associated event
  * (same as ConversationRow); falls back to a UserAvatar otherwise.
  */
-const NotificationRow = ({ notification, onPress, nowMs, eventImageUri }: NotificationRowProps) => {
+const NotificationRow = ({
+  notification,
+  onPress,
+  nowMs,
+  eventImageUri,
+  isLast,
+}: NotificationRowProps) => {
   const hasUnread = !notification.read;
   const timestampLabel = formatCompactRelativeTime(notification.createdAt, nowMs);
 
@@ -80,7 +87,7 @@ const NotificationRow = ({ notification, onPress, nowMs, eventImageUri }: Notifi
           </Text>
         </View>
       </View>
-      <View style={styles.divider} />
+      {!isLast && <View style={styles.divider} />}
     </ScalePressable>
   );
 };
@@ -164,7 +171,7 @@ const styles = StyleSheet.create({
   },
   divider: {
     height: 1,
-    backgroundColor: '#F0F0F0',
+    backgroundColor: colors.divider,
     marginLeft: spacing.md + 52 + 12,
   },
 });

--- a/src/components/events/EventMemberRow.tsx
+++ b/src/components/events/EventMemberRow.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 1,
-    backgroundColor: colors.border,
+    backgroundColor: colors.divider,
     marginLeft: 48, // avatar (40) + gap (8)
     marginBottom: 12,
   },

--- a/src/components/events/EventRequestRow.tsx
+++ b/src/components/events/EventRequestRow.tsx
@@ -152,7 +152,7 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 1,
-    backgroundColor: colors.border,
+    backgroundColor: colors.divider,
     marginLeft: 48, // avatar (40) + gap (8)
     marginTop: spacing.sm + 6,
     marginBottom: spacing.sm + 6,

--- a/src/screens/HelpFAQScreen.tsx
+++ b/src/screens/HelpFAQScreen.tsx
@@ -141,13 +141,15 @@ const FaqAccordionItem = ({
   answer,
   isExpanded,
   onPress,
+  isLast,
 }: {
   title: string;
   answer: FaqAnswerBlock[];
   isExpanded: boolean;
   onPress: () => void;
+  isLast: boolean;
 }) => (
-  <View style={styles.faqItem}>
+  <View style={[styles.faqItem, isLast && styles.faqItemLast]}>
     <ScalePressable
       accessibilityRole="button"
       accessibilityState={{ expanded: isExpanded }}
@@ -209,6 +211,7 @@ const HelpFAQScreen = () => {
             key={item.title}
             title={item.title}
             answer={item.answer}
+            isLast={index === FAQ_ITEMS.length - 1}
             isExpanded={expandedIndices.has(index)}
             onPress={() => {
               setExpandedIndices((current) => {
@@ -232,7 +235,10 @@ const styles = StyleSheet.create({
   },
   faqItem: {
     borderBottomWidth: 1,
-    borderBottomColor: colors.borderSubtle,
+    borderBottomColor: colors.divider,
+  },
+  faqItemLast: {
+    borderBottomWidth: 0,
   },
   faqRow: {
     paddingVertical: 20,

--- a/src/screens/HelpScreen.tsx
+++ b/src/screens/HelpScreen.tsx
@@ -30,9 +30,9 @@ const HelpScreen = () => {
       <ScreenHeader title="Help" onBack={navigation.goBack} />
       <View style={styles.menuList}>
         <MenuItem label="Contact us" onPress={() => navigation.navigate('HelpContact')} />
-        <ListSeparator />
+        <ListSeparator style={styles.separator} />
         <MenuItem label="FAQ" onPress={() => navigation.navigate('HelpFAQ')} />
-        <ListSeparator />
+        <ListSeparator style={styles.separator} />
         <MenuItem label="Feedback" onPress={() => navigation.navigate('HelpFeedback')} />
       </View>
     </ScreenContainer>
@@ -42,6 +42,10 @@ const HelpScreen = () => {
 const styles = StyleSheet.create({
   menuList: {
     paddingTop: 15,
+  },
+  separator: {
+    height: 1, // match the account page divider thickness
+    backgroundColor: colors.divider, // match the app-wide line separator color
   },
   menuItem: {},
   menuItemInner: {

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -378,11 +378,6 @@ const JoinRequestsScreen = () => {
           ItemSeparatorComponent={() => (
             <View style={is1to1Mode ? styles.separator1to1 : styles.separator} />
           )}
-          ListFooterComponent={
-            displayRequests.length > 0 ? (
-              <View style={is1to1Mode ? styles.separator1to1 : styles.separator} />
-            ) : null
-          }
           contentContainerStyle={
             displayRequests.length === 0
               ? styles.listEmptyContent
@@ -423,12 +418,12 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 1,
-    backgroundColor: colors.border,
+    backgroundColor: colors.divider,
     marginLeft: 48, // avatar (40) + gap (8) — align after the avatar
   },
   separator1to1: {
     height: 1,
-    backgroundColor: colors.border,
+    backgroundColor: colors.divider,
     marginLeft: 64, // avatar (40) + gap (8) + list marginLeft offset (16)
   },
   // Group mode request item styles

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -42,6 +42,7 @@ const ConversationRow = ({
   events,
   userId,
   nowMs,
+  isLast,
 }: {
   item: ChatConversation;
   onPress: (item: ChatConversation) => void;
@@ -49,6 +50,7 @@ const ConversationRow = ({
   events: { id: string; imageUri: string }[];
   userId?: number;
   nowMs: number;
+  isLast: boolean;
 }) => {
   const { participants = [] } = item;
   const counterpart = participants.find((p) => p.id !== userId) ?? participants[0];
@@ -133,7 +135,7 @@ const ConversationRow = ({
           </Text>
         </View>
       </View>
-      <View style={styles.conversationDivider} />
+      {!isLast && <View style={styles.conversationDivider} />}
     </ScalePressable>
   );
 };
@@ -311,7 +313,7 @@ const MessagesScreen = () => {
     }
   };
 
-  const renderConversation = ({ item }: { item: ChatConversation }) => {
+  const renderConversation = ({ item, index }: { item: ChatConversation; index: number }) => {
     return (
       <ConversationRow
         item={item}
@@ -320,6 +322,7 @@ const MessagesScreen = () => {
         events={events}
         userId={user?.id}
         nowMs={relativeTimeNow}
+        isLast={index === displayConversations.length - 1}
       />
     );
   };
@@ -467,7 +470,7 @@ const styles = StyleSheet.create({
   },
   conversationDivider: {
     height: 1,
-    backgroundColor: '#F0F0F0',
+    backgroundColor: colors.divider,
     marginLeft: spacing.md + 52 + 12,
   },
   conversationName: {

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -181,11 +181,12 @@ const NotificationsScreen = () => {
         <FlatList
           data={notifications}
           keyExtractor={(item) => String(item.id)}
-          renderItem={({ item }) => (
+          renderItem={({ item, index }) => (
             <NotificationRow
               notification={item}
               onPress={handleRowPress}
               nowMs={nowMs}
+              isLast={index === notifications.length - 1}
               eventImageUri={
                 item.eventId != null
                   ? events.find((event) => Number(event.id) === item.eventId)?.imageUri

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -51,6 +51,7 @@ interface MenuItemProps {
   showChevron?: boolean;
   haptic?: HapticFeedback;
   testID?: string;
+  isLast?: boolean;
 }
 
 const MenuItem = ({
@@ -60,6 +61,7 @@ const MenuItem = ({
   showChevron = true,
   haptic = 'light',
   testID,
+  isLast = false,
 }: MenuItemProps) => {
   const handlePress = () => {
     triggerHaptic(haptic);
@@ -68,7 +70,7 @@ const MenuItem = ({
 
   return (
     <ScalePressable
-      pressableStyle={styles.menuItem}
+      pressableStyle={[styles.menuItem, isLast && styles.menuItemLast]}
       style={styles.menuItemInner}
       onPress={handlePress}
       testID={testID}
@@ -236,6 +238,7 @@ const ProfileScreen = () => {
               icon={<HelpIcon width={20} height={20} color={colors.text} />}
               label="Help"
               onPress={handleHelp}
+              isLast
             />
           </View>
         </ScrollView>
@@ -357,6 +360,7 @@ const ProfileScreen = () => {
             onPress={handleDelete}
             showChevron={false}
             haptic="destructive"
+            isLast
           />
         </View>
       </ScrollView>
@@ -498,8 +502,11 @@ const styles = StyleSheet.create({
     paddingTop: 12,
   },
   menuItem: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.borderSubtle,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.divider,
+  },
+  menuItemLast: {
+    borderBottomWidth: 0,
   },
   menuItemInner: {
     flexDirection: 'row',

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -25,6 +25,7 @@ export const colors = {
   subText: '#808080',
   border: '#E5E7EB',
   borderSubtle: '#E6E6E6',
+  divider: '#F5F5F5', // subtle row divider / line separator (1px) — chat, member/request lists, account, help
   checkboxBorder: '#D0D0D0',
   inputSurface: '#F4F4F4',
   error: '#FF383C',


### PR DESCRIPTION
**Description:**
  
The line separators (dividers) in lists were inconsistent — different colors, different thicknesses, and some lists showed a divider after the last item while others didn't. This makes them all match.

### Added
- A shared **`divider` color token** (`colors.divider`) as the single source of truth for every list line separator.
  
### Changed
- **One consistent divider color everywhere.** Chat, notifications, member/ request lists, join requests, the account (Profile) menu, the Help menu, and the Help → FAQ list now all use the same subtle separator color. Previously they used a mix of three different greys.
- **One consistent thickness (1px).** Some dividers were 1px, others were thinner half-pixel lines that rendered unevenly (a faint line in one spot, a crisp one in another, depending on position). All are now a crisp, uniform 1px.
- **Lightened the divider color** so the 1px line still reads as subtle.
- Replaced scattered hard-coded divider colors (chat, notifications) with the shared token.

### Removed
- **The divider after the last item in every list.** Dividers now appear only *between* rows — no stray line hanging under the final chat, notification, request, account-menu, or FAQ item.

---

**After**

<img width="585" height="1266" alt="IMG_0591" src="https://github.com/user-attachments/assets/a6616f00-b9e4-46b4-b23a-f8f705ed1ad0" />
<img width="585" height="1266" alt="IMG_0592" src="https://github.com/user-attachments/assets/c0a0f830-b404-4ada-b84a-7f46a317dd84" />
<img width="585" height="1266" alt="IMG_0593" src="https://github.com/user-attachments/assets/d0979fc5-25b1-49d9-bb77-33a227298b1a" />
<img width="585" height="1266" alt="IMG_0594" src="https://github.com/user-attachments/assets/597375c8-30c3-4a98-8084-d4552316ac24" />
<img width="585" height="1266" alt="Screenshot 2026-07-17 at 6 43 28 p m" src="https://github.com/user-attachments/assets/be95ebf0-6b04-42a4-99b6-ed3c903fbbd9" />
