### PR TITLE
polish: chat ui

### DIFF
--- a/src/components/ChatEventHeader.tsx
+++ b/src/components/ChatEventHeader.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { colors, spacing, typography } from "@theme/index";
 import ChevronLeftIcon from "@assets/ui/chevron-left.svg";
+import ScalePressable from "@components/ScalePressable";
 
 interface ChatEventHeaderProps {
   onBack: () => void;
@@ -37,6 +38,62 @@ const ChatEventHeader = ({
 }: ChatEventHeaderProps) => {
   const hasCover = coverSource != null || (coverUri != null && coverUri !== "");
 
+  // Split "One to one, 23 Jul Thu" on the first comma so the comma can be
+  // rendered as a small dot separator (a filled circle) instead of a comma.
+  const subtitleSepIndex = subtitle ? subtitle.indexOf(", ") : -1;
+  const subtitleLeft = subtitleSepIndex >= 0 ? subtitle!.slice(0, subtitleSepIndex) : null;
+  const subtitleRight = subtitleSepIndex >= 0 ? subtitle!.slice(subtitleSepIndex + 2) : null;
+
+  const titleInner = (
+    <>
+      {leadingElement ?? (hasCover ? (
+        <Image source={coverSource ?? { uri: coverUri! }} style={styles.coverImage} />
+      ) : null)}
+      <View style={styles.textContainer}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+        {subtitle ? (
+          subtitleLeft != null && subtitleRight != null ? (
+            <View style={styles.subtitleRow}>
+              <Text style={styles.subtitleInline} numberOfLines={1}>
+                {subtitleLeft}
+              </Text>
+              <View style={styles.subtitleDot} />
+              <Text style={[styles.subtitleInline, styles.subtitleRight]} numberOfLines={1}>
+                {subtitleRight}
+              </Text>
+            </View>
+          ) : (
+            <Text style={styles.subtitle} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          )
+        ) : null}
+      </View>
+    </>
+  );
+
+  // Tappable header (opens event/member details) scales like the chat rows;
+  // otherwise it's a plain, non-interactive block.
+  const titleContent = onTitlePress ? (
+    // flex/row layout must be on the OUTER Pressable (pressableStyle) so the
+    // header expands; the inner Animated.View (style) fills it and lays out the row.
+    <ScalePressable
+      pressableStyle={styles.titlePressable}
+      style={styles.titlePressableInner}
+      onPress={onTitlePress}
+      accessibilityLabel={titleAccessibilityLabel ?? "View event details"}
+      testID={testID}
+    >
+      {titleInner}
+    </ScalePressable>
+  ) : (
+    <View style={styles.titlePressable} testID={testID}>
+      {titleInner}
+    </View>
+  );
+
   return (
     <View style={styles.container}>
       <Pressable
@@ -48,30 +105,7 @@ const ChatEventHeader = ({
       >
         <ChevronLeftIcon width={24} height={24} color={colors.text} />
       </Pressable>
-      <Pressable
-        style={({ pressed }) => [styles.titlePressable, pressed && { opacity: 0.7 }]}
-        onPress={onTitlePress}
-        accessibilityRole={onTitlePress ? "button" : undefined}
-        accessibilityLabel={titleAccessibilityLabel ?? "View event details"}
-        testID={testID}
-      >
-        {leadingElement ?? (hasCover ? (
-          <Image
-            source={coverSource ?? { uri: coverUri! }}
-            style={styles.coverImage}
-          />
-        ) : null)}
-        <View style={styles.textContainer}>
-          <Text style={styles.title} numberOfLines={1}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text style={styles.subtitle} numberOfLines={1}>
-              {subtitle}
-            </Text>
-          ) : null}
-        </View>
-      </Pressable>
+      {titleContent}
       {rightElement ?? null}
     </View>
   );
@@ -84,14 +118,33 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.sm,
+    // Full-bleed bottom divider (matches the shared row separator). Negative
+    // horizontal margin extends the line to the screen edges past the
+    // ScreenContainer padding; paddingHorizontal keeps the content at 16px.
+    marginHorizontal: -spacing.md,
+    paddingHorizontal: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.divider,
   },
   backButton: {
+    // The chevron artwork is inset ~8px inside its 24px SVG box, so pull the
+    // button left by that much to align the visible chevron with the 16px
+    // screen content margin (where the message rows / avatars start).
+    marginLeft: -spacing.sm,
     paddingRight: spacing.xs,
     paddingVertical: spacing.xs,
     alignItems: "center",
     justifyContent: "center",
   },
   titlePressable: {
+    flexDirection: "row",
+    alignItems: "center",
+    flex: 1,
+    gap: spacing.sm,
+  },
+  // Inner Animated.View of the tappable header: fills the outer Pressable and
+  // carries the same row layout so avatar + text lay out correctly.
+  titlePressableInner: {
     flexDirection: "row",
     alignItems: "center",
     flex: 1,
@@ -115,13 +168,39 @@ const styles = StyleSheet.create({
     color: "#000000",
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: 13,
     fontFamily: typography.fontFamilyRegular,
     fontWeight: "400",
     lineHeight: 20,
     letterSpacing: -0.5,
     color: "#707070",
     marginTop: 2,
+  },
+  subtitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 2,
+  },
+  subtitleInline: {
+    fontSize: 13,
+    fontFamily: typography.fontFamilyRegular,
+    fontWeight: "400",
+    lineHeight: 20,
+    letterSpacing: -0.5,
+    color: "#707070",
+  },
+  subtitleRight: {
+    flexShrink: 1, // let the date truncate before the label
+  },
+  // Filled dot separator (replaces the comma). A small solid dot reads heavier
+  // than text at the same color, so drop its opacity to match the text weight.
+  subtitleDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 999,
+    backgroundColor: "#707070",
+    opacity: 0.6,
+    marginHorizontal: 5,
   },
 });
 

--- a/src/components/events/EventMemberRow.tsx
+++ b/src/components/events/EventMemberRow.tsx
@@ -101,6 +101,7 @@ const styles = StyleSheet.create({
     lineHeight: 14,
     letterSpacing: -0.5,
     color: colors.fieldLabel,
+    marginRight: 8, // match the menu button's padding so "Host" aligns with the "…" icons
   },
 });
 

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -70,7 +70,7 @@ const ChatComposer = ({
         value={draft}
         onChangeText={onDraftChange}
         style={styles.composerInput}
-        placeholderTextColor={colors.muted}
+        placeholderTextColor={colors.tabInactive}
         multiline
       />
       <Pressable
@@ -484,8 +484,18 @@ const ChatThreadScreen = () => {
         prevMessage.body.toLowerCase() === 'updated event detail'
       : false;
     const isFirstInRun = !prevMessage || prevMessage.senderId !== item.senderId || prevIsSystem;
+
+    const nextMessage = index < messages.length - 1 ? messages[index + 1] : null;
+    const nextIsSystem = nextMessage
+      ? nextMessage.body.toLowerCase().endsWith('joined the chat') ||
+        nextMessage.body.toLowerCase() === 'updated event detail'
+      : false;
+    const isLastInRun = !nextMessage || nextMessage.senderId !== item.senderId || nextIsSystem;
+
     const showAvatar = !isOwn;
     const showName = showAvatar && isFirstInRun;
+    // Every message shows its own inline timestamp (kept compact by being inline).
+    const showMeta = true;
 
     const timeText = item.pending
       ? 'Sending…'
@@ -504,21 +514,22 @@ const ChatThreadScreen = () => {
           item.failed ? styles.messageBubbleFailed : undefined,
         ]}
       >
-        {showName && firstName ? <Text style={styles.senderName}>{firstName}</Text> : null}
         <Text style={[styles.messageText, isOwn ? styles.messageTextOwn : styles.messageTextOther]}>
           {item.body}
-        </Text>
-        <Text
-          style={[
-            styles.messageMeta,
-            item.failed
-              ? styles.messageMetaFailed
-              : isOwn
-                ? styles.messageMetaOwn
-                : styles.messageMetaOther,
-          ]}
-        >
-          {timeText}
+          {showMeta ? (
+            <Text
+              style={[
+                styles.messageMeta,
+                item.failed
+                  ? styles.messageMetaFailed
+                  : isOwn
+                    ? styles.messageMetaOwn
+                    : styles.messageMetaOther,
+              ]}
+            >
+              {`  ${timeText}`}
+            </Text>
+          ) : null}
         </Text>
       </View>
     );
@@ -537,9 +548,16 @@ const ChatThreadScreen = () => {
     );
 
     return (
-      <View style={[styles.messageRow, isOwn ? styles.messageRowOwn : styles.messageRowOther]}>
+      <View
+        style={[
+          styles.messageRow,
+          isOwn ? styles.messageRowOwn : styles.messageRowOther,
+          // Tight gap within a run, full gap between senders (grouping).
+          { marginBottom: isLastInRun ? spacing.sm : 3 },
+        ]}
+      >
         {showAvatar ? (
-          isFirstInRun ? (
+          isLastInRun ? (
             <UserAvatar
               avatar={participant?.avatar}
               name={senderName}
@@ -551,13 +569,17 @@ const ChatThreadScreen = () => {
             <View style={styles.avatarSpacer} />
           )
         ) : null}
-        <View style={styles.messageBubbleContainer}>{bubbleContent}</View>
+        <View style={styles.messageBubbleContainer}>
+          {showName && firstName ? <Text style={styles.senderName}>{firstName}</Text> : null}
+          {bubbleContent}
+        </View>
       </View>
     );
   };
 
   const composerProps: ComposerProps = {
-    activeConversationName: activeConversation.displayName,
+    // Placeholder name matches the header title: counterpart in 1:1, group/event name otherwise.
+    activeConversationName: headerTitle,
     composerBottomPadding,
     draft,
     isSendDisabled,
@@ -734,21 +756,22 @@ const styles = StyleSheet.create({
     marginRight: spacing.xs,
     flexShrink: 0,
   },
+  // Sender label above the bubble: distinct from the smaller, centered system notices.
   senderName: {
-    fontSize: 17,
-    fontFamily: typography.fontFamilyMedium,
-    fontWeight: '500',
-    lineHeight: 22,
-    letterSpacing: -0.5,
-    color: colors.text,
-    marginBottom: 2,
+    fontSize: 13,
+    fontFamily: typography.fontFamilyRegular,
+    lineHeight: 16,
+    letterSpacing: -0.3,
+    color: colors.subText,
+    marginBottom: 4,
+    marginLeft: spacing.md, // = messageBubble paddingLeft, so the name lines up with the text
   },
   messageBubble: {
-    paddingTop: 12,
-    paddingBottom: 12,
-    paddingLeft: 16,
-    paddingRight: 16,
-    borderRadius: 20,
+    paddingTop: 10,
+    paddingBottom: 10,
+    paddingLeft: 14,
+    paddingRight: 14,
+    borderRadius: 18,
     borderCurve: 'continuous',
   },
   messageBubbleOwn: {
@@ -763,7 +786,7 @@ const styles = StyleSheet.create({
     borderColor: colors.accent,
   },
   messageText: {
-    fontSize: 17,
+    fontSize: 16,
     fontFamily: typography.fontFamilyRegular,
     fontWeight: '400',
     lineHeight: 22,
@@ -775,14 +798,12 @@ const styles = StyleSheet.create({
   messageTextOther: {
     color: colors.text,
   },
+  // Inline timestamp appended to the message text (nested Text).
   messageMeta: {
-    marginTop: 4,
     fontSize: 11,
     fontFamily: typography.fontFamilyRegular,
     fontWeight: '400',
-    lineHeight: 11,
     letterSpacing: -0.3,
-    textAlign: 'right',
   },
   messageMetaOwn: {
     color: colors.buttonText,
@@ -797,11 +818,12 @@ const styles = StyleSheet.create({
   systemMessageRow: {
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: 12,
+    marginBottom: 8,
     paddingHorizontal: spacing.lg,
   },
+  // Quiet system notices: small (12) keeps them recessive; grey stays readable.
   systemMessageText: {
-    fontSize: typography.caption,
+    fontSize: 12,
     color: colors.subText,
     textAlign: 'center',
     letterSpacing: -0.3,
@@ -826,7 +848,7 @@ const styles = StyleSheet.create({
     paddingLeft: 12,
     paddingRight: spacing.sm,
     fontFamily: typography.fontFamilyRegular,
-    fontSize: 16,
+    fontSize: 15,
     letterSpacing: -0.3,
   },
   sendIconButton: {

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -214,7 +214,10 @@ const EventDetailsScreenContent = ({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Close event details"
-              onPress={handleOverlayClose}
+              onPress={() => {
+                triggerHaptic('light');
+                handleOverlayClose();
+              }}
               style={styles.fallbackCloseButton}
             >
               <CloseIcon width={24} height={24} color={colors.text} />
@@ -281,7 +284,10 @@ const EventDetailsScreenContent = ({
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Close event details"
-            onPress={handleOverlayClose}
+            onPress={() => {
+              triggerHaptic('light');
+              handleOverlayClose();
+            }}
             style={[
               styles.overlayCloseButton,
               styles.overlayCloseButtonFixed,
@@ -289,6 +295,7 @@ const EventDetailsScreenContent = ({
             ]}
             hitSlop={12}
           >
+            <BlurView intensity={24} tint="dark" style={StyleSheet.absoluteFill} />
             <CloseIcon width={24} height={24} color={colors.buttonText} />
           </Pressable>
         ) : !readOnly ? (
@@ -623,7 +630,10 @@ const EventDetailsScreen = ({ onOverlayClose }: EventDetailsScreenProps = {}) =>
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Close event details"
-                  onPress={handleOverlayClose}
+                  onPress={() => {
+                    triggerHaptic('light');
+                    handleOverlayClose();
+                  }}
                   style={styles.fallbackCloseButton}
                 >
                   <CloseIcon width={24} height={24} color={colors.text} />

--- a/src/screens/JoinRequestsScreen.tsx
+++ b/src/screens/JoinRequestsScreen.tsx
@@ -6,6 +6,7 @@ import AcceptIcon from '@assets/event-details/accept.svg';
 import RejectIcon from '@assets/event-details/reject.svg';
 import EmptyState from '@components/EmptyState';
 import FullPageEmptyState from '@components/FullPageEmptyState';
+import ScalePressable from '@components/ScalePressable';
 
 import { colors, spacing, typography } from '@theme/index';
 import { useChat, ChatJoinRequest } from '@context/ChatContext';
@@ -268,9 +269,10 @@ const JoinRequestsScreen = () => {
     const hasUnread = (convo?.unreadCount ?? 0) > 0;
 
     return (
-      <Pressable
-        style={({ pressed }) => [styles.requestRow1to1, pressed && styles.requestRowPressed]}
+      <ScalePressable
+        style={styles.requestRow1to1}
         onPress={() => handleRequesterPress(item)}
+        accessibilityLabel={`Open chat with ${item.requester.name}`}
       >
         {hasUnread && (
           <View style={styles.unreadDot1to1Wrap}>
@@ -294,7 +296,7 @@ const JoinRequestsScreen = () => {
             {previewText}
           </Text>
         </View>
-      </Pressable>
+      </ScalePressable>
     );
   };
 
@@ -337,28 +339,22 @@ const JoinRequestsScreen = () => {
           {item.message ? <Text style={styles.requestMessage}>{item.message}</Text> : null}
         </View>
         <View style={styles.requestActions}>
-          <Pressable
-            accessibilityRole="button"
+          <ScalePressable
+            haptic="destructive"
             accessibilityLabel={`Decline request from ${item.requester.name}`}
-            onPress={() => {
-              triggerHaptic('destructive');
-              handleAction(item.id, item.userId, 'deny');
-            }}
+            onPress={() => handleAction(item.id, item.userId, 'deny')}
             style={styles.declineButton}
           >
             <RejectIcon width={30} height={30} />
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
+          </ScalePressable>
+          <ScalePressable
+            haptic="submit"
             accessibilityLabel={`Accept request from ${item.requester.name}`}
-            onPress={() => {
-              triggerHaptic('submit');
-              handleAction(item.id, item.userId, 'approve');
-            }}
+            onPress={() => handleAction(item.id, item.userId, 'approve')}
             style={styles.acceptButton}
           >
             <AcceptIcon width={30} height={30} />
-          </Pressable>
+          </ScalePressable>
         </View>
       </View>
     );
@@ -490,9 +486,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.md,
     paddingLeft: spacing.md,
     gap: spacing.sm,
-  },
-  requestRowPressed: {
-    backgroundColor: 'rgba(0,0,0,0.03)',
   },
   requestInfo1to1: {
     flex: 1,

--- a/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
+++ b/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
@@ -126,7 +126,6 @@ describe('ChatThreadScreen Rendering', () => {
 
   const today = new Date();
   const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-  const todayAbsoluteLabel = `${String(today.getDate()).padStart(2, '0')} ${today.toLocaleString('en-US', { month: 'short' })} ${today.toLocaleString('en-US', { weekday: 'short' })}`;
 
   const setupMocks = (overrides: {
     authOverrides?: object;
@@ -167,9 +166,10 @@ describe('ChatThreadScreen Rendering', () => {
       setupMocks();
       const { getByText } = render(<ChatThreadScreen />);
 
-      expect(getByText('Hello everyone!')).toBeTruthy();
-      expect(getByText('Hi there! Looking forward to the meetup.')).toBeTruthy();
-      expect(getByText('See you soon!')).toBeTruthy();
+      // Body shares its Text node with the inline timestamp, so match a substring.
+      expect(getByText(/Hello everyone!/)).toBeTruthy();
+      expect(getByText(/Hi there! Looking forward to the meetup/)).toBeTruthy();
+      expect(getByText(/See you soon!/)).toBeTruthy();
     });
 
     it('should display conversation title in header', () => {
@@ -179,7 +179,7 @@ describe('ChatThreadScreen Rendering', () => {
       expect(getByText('Coffee Meetup Chat')).toBeTruthy();
     });
 
-    it('should render member count and date subtitle in group mode using dateLabel as-is', () => {
+    it('should render "Group" and the member count subtitle in group mode', () => {
       setupMocks({
         chatOverrides: {
           conversations: [
@@ -197,8 +197,9 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { getByText } = render(<ChatThreadScreen />);
 
-      // 2 members (memberIds: [1, 2]) + legacy date label, no time/location reformatting
-      expect(getByText('2 Members, Today')).toBeTruthy();
+      // Subtitle: "Group · 2 Members" (memberIds: [1, 2]) — two parts, dot separator.
+      expect(getByText('Group')).toBeTruthy();
+      expect(getByText('2 Members')).toBeTruthy();
     });
 
     it('should render counterpart name and "One to one, <date>" subtitle in 1:1 mode', () => {
@@ -221,7 +222,8 @@ describe('ChatThreadScreen Rendering', () => {
       const { getByText } = render(<ChatThreadScreen />);
 
       expect(getByText('Liam Test')).toBeTruthy();
-      expect(getByText('One to one, Today')).toBeTruthy();
+      expect(getByText('One to one')).toBeTruthy();
+      expect(getByText('Today')).toBeTruthy();
     });
 
     it('should render own messages with appropriate styling', () => {
@@ -229,7 +231,7 @@ describe('ChatThreadScreen Rendering', () => {
       const { getByText } = render(<ChatThreadScreen />);
 
       // Messages from current user (id: 1)
-      const ownMessage = getByText('Hello everyone!');
+      const ownMessage = getByText(/Hello everyone!/);
       expect(ownMessage).toBeTruthy();
     });
 
@@ -238,7 +240,7 @@ describe('ChatThreadScreen Rendering', () => {
       const { getByText } = render(<ChatThreadScreen />);
 
       // Message from user id: 2
-      const otherMessage = getByText('Hi there! Looking forward to the meetup.');
+      const otherMessage = getByText(/Hi there! Looking forward to the meetup/);
       expect(otherMessage).toBeTruthy();
     });
 
@@ -353,7 +355,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { getByText } = render(<ChatThreadScreen />);
 
-      const failedMessageText = getByText('Failed to send');
+      const failedMessageText = getByText(/Failed to send/);
       fireEvent.press(failedMessageText);
 
       expect(mockRetryMessage).toHaveBeenCalledWith(1, mockFailedMessage);
@@ -387,7 +389,8 @@ describe('ChatThreadScreen Rendering', () => {
       const { getByText } = render(<ChatThreadScreen />);
 
       // Subtitle is NOT replaced by the connecting indicator
-      expect(getByText(`2 Members, ${todayAbsoluteLabel}`)).toBeTruthy();
+      expect(getByText('Group')).toBeTruthy();
+      expect(getByText('2 Members')).toBeTruthy();
     });
 
     it('should display error message when error exists', () => {

--- a/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
@@ -25,7 +25,6 @@ const mockRouteParams = {
 
 const today = new Date();
 const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-const todayAbsoluteLabel = `${String(today.getDate()).padStart(2, '0')} ${today.toLocaleString('en-US', { month: 'short' })} ${today.toLocaleString('en-US', { weekday: 'short' })}`;
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -342,7 +341,9 @@ describe('JoinRequestsScreen Rendering', () => {
     it('should render member count and date subtitle in group mode', () => {
       mockChatValue.conversations = [mockConversation()];
       const { getByText } = render(<JoinRequestsScreen />);
-      expect(getByText(`3 Members, ${todayAbsoluteLabel}`)).toBeTruthy();
+      // Subtitle: "Group · 3 Members" (two parts, dot separator).
+      expect(getByText('Group')).toBeTruthy();
+      expect(getByText('3 Members')).toBeTruthy();
     });
 
     it('should render back button', () => {
@@ -483,7 +484,9 @@ describe('JoinRequestsScreen Rendering', () => {
       const { getByText } = render(<JoinRequestsScreen />);
 
       // Only the 2 approved requesters are counted; the host is excluded.
-      expect(getByText(`2 Accepted, ${todayAbsoluteLabel}`)).toBeTruthy();
+      // Subtitle: "1:1 · 2 Accepted" (two parts, dot separator).
+      expect(getByText('1:1')).toBeTruthy();
+      expect(getByText('2 Accepted')).toBeTruthy();
     });
 
     it('should render pending requests icon with count badge in 1:1 mode', () => {
@@ -667,7 +670,9 @@ describe('JoinRequestsScreen Rendering', () => {
     it('should show empty accepted state by default', () => {
       const { getByText } = render(<JoinRequestsScreen />);
 
-      expect(getByText(`0 Accepted, ${todayAbsoluteLabel}`)).toBeTruthy();
+      // Subtitle: "1:1 · 0 Accepted" (two parts, dot separator).
+      expect(getByText('1:1')).toBeTruthy();
+      expect(getByText('0 Accepted')).toBeTruthy();
       expect(getByText('No accepted members yet')).toBeTruthy();
     });
 

--- a/src/screens/event-details/EventDetailsScreen.styles.ts
+++ b/src/screens/event-details/EventDetailsScreen.styles.ts
@@ -65,7 +65,10 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: 'rgba(0, 0, 0, 0.15)',
+    // Frosted glass to match the back/menu buttons: BlurView fills the circle;
+    // overflow clips it round, faint tint keeps the white ✕ readable.
+    backgroundColor: 'rgba(0, 0, 0, 0.08)',
+    overflow: 'hidden',
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/utils/__tests__/chatHeaderSubtitle.test.ts
+++ b/src/utils/__tests__/chatHeaderSubtitle.test.ts
@@ -17,54 +17,53 @@ const absoluteFor = (eventDate: string) => {
 
 describe('buildEventMemberSubtitle', () => {
   const eventDate = todayKey();
-  const absoluteLabel = absoluteFor(eventDate);
 
-  it('uses "Accepted" wording for Single group type', () => {
+  it('leads with "1:1" then the accepted count for Single', () => {
     expect(
       buildEventMemberSubtitle({
         groupType: 'Single',
         memberCount: 3,
         schedule: { eventDate },
       }),
-    ).toBe(`3 Accepted, ${absoluteLabel}`);
+    ).toBe('1:1, 3 Accepted');
   });
 
-  it('uses "Members" wording for Group group type', () => {
+  it('leads with "Group" then the member count for Group', () => {
     expect(
       buildEventMemberSubtitle({
         groupType: 'Group',
         memberCount: 3,
         schedule: { eventDate },
       }),
-    ).toBe(`3 Members, ${absoluteLabel}`);
+    ).toBe('Group, 3 Members');
   });
 
-  it('falls back to the legacy dateLabel when no eventDate is present', () => {
+  it('ignores the schedule (no date in the subtitle)', () => {
     expect(
       buildEventMemberSubtitle({
         groupType: 'Group',
         memberCount: 5,
         schedule: { dateLabel: 'Today' },
       }),
-    ).toBe('5 Members, Today');
-  });
+    ).toBe('Group, 5 Members');
 
-  it('returns only the count part when no schedule is available', () => {
     expect(
       buildEventMemberSubtitle({
         groupType: 'Single',
         memberCount: 2,
         schedule: null,
       }),
-    ).toBe('2 Accepted');
+    ).toBe('1:1, 2 Accepted');
+  });
 
+  it('treats undefined group type as Group', () => {
     expect(
       buildEventMemberSubtitle({
         groupType: undefined,
         memberCount: 2,
         schedule: undefined,
       }),
-    ).toBe('2 Members');
+    ).toBe('Group, 2 Members');
   });
 
   it('handles a zero count', () => {
@@ -74,7 +73,7 @@ describe('buildEventMemberSubtitle', () => {
         memberCount: 0,
         schedule: { dateLabel: 'Today' },
       }),
-    ).toBe('0 Members, Today');
+    ).toBe('Group, 0 Members');
   });
 });
 

--- a/src/utils/chatHeaderSubtitle.ts
+++ b/src/utils/chatHeaderSubtitle.ts
@@ -35,20 +35,18 @@ export interface EventMemberSubtitleOptions {
  * Build the event-level subtitle shared by JoinRequestsScreen and the group
  * chat window:
  *
- *   Single → "3 Accepted, 08 Jun Mon"
- *   Group  → "3 Members, 08 Jun Mon"
+ *   Single → "1:1, 3 Accepted"
+ *   Group  → "Group, 3 Members"
  *
- * Falls back to just the date (or an empty string) when no schedule exists.
+ * (The comma is rendered as a dot separator by ChatEventHeader.)
  */
 export const buildEventMemberSubtitle = ({
   groupType,
   memberCount,
-  schedule,
 }: EventMemberSubtitleOptions): string => {
-  const dateLabel = resolveDateLabel(schedule);
+  const typeLabel = groupType === 'Single' ? '1:1' : 'Group';
   const noun = groupType === 'Single' ? 'Accepted' : 'Members';
-  const countPart = `${memberCount} ${noun}`;
-  return dateLabel ? `${countPart}, ${dateLabel}` : countPart;
+  return `${typeLabel}, ${memberCount} ${noun}`;
 };
 
 export interface OneToOneSubtitleOptions {


### PR DESCRIPTION
### Polish: Chat UI — message layout, header, subtitles, press feedback

**Description**

A polish pass across the chat screens (conversation, chat header, and the join-requests/accepted-members list). Improves message readability and grouping, cleans up the header, standardizes the subtitle format, and adds consistent press feedback. One commit, 10 files.


**Changed — message bubbles (ChatThreadScreen)**

- Sender name moved out of the bubble to a subtle grey label above it (was inside the bubble).
- Timestamp is now inline, right after the message text, instead of on its own line below it — so short one-word messages are a single line instead of forced to two.
- Messages from the same sender are grouped: tighter spacing within a run, normal gap between senders, and the avatar sits on the last message of the run.
- Tighter bubbles: padding 12→10 / 16→14, corner radius 20→18.
- Message text size 17 → 16.
- System notices ("X joined the chat") made quieter: size 14 → 12, tighter spacing.
- Composer placeholder now uses the person's name in a 1:1 chat ("Message Sumit") instead of the event name; input font 16 → 15; placeholder color lightened so it reads as a hint, not typed text.


**Changed — chat header (ChatEventHeader)**

- The subtitle's comma is now a small filled dot separator (e.g. "One to one · 23 Jul Thu").
- Added a full-width divider under the header on all chat child pages.
- Back chevron aligned to the screen content margin (was inset ~8px too far right).
- Subtitle font 14 → 13.
- Header title/avatar now scale-presses when tapped (was an opacity fade).


**Changed — subtitle format (chatHeaderSubtitle)**

- Leads with the event type and drops the date: "1:1 · 3 Accepted" and "Group · 3 Members" (was "3 Accepted · date" / "3 Members · date"). Applies to the group chat header and the accepted-members list.
  
  
**Changed — press feedback & event-details overlay**

- 1:1 accepted-member rows and the Accept/Decline buttons on group requests now use the scale-press animation (matching the Messages list).
- The Event Details overlay close (✕) button: added a light haptic + frosted-glass blur behind it, matching the back/menu buttons.
- "Host" label in member rows nudged left so it aligns with the "···" menu icons above/below it.


**Tests**

- Updated chat/join-requests/subtitle test assertions for the new inline-timestamp text, the split dot-separator
  subtitle, and the new "1:1 / Group" wording.

---

**After**

<img width="2430" height="2830" alt="image" src="https://github.com/user-attachments/assets/f7ea1f1b-1257-4cf9-be94-521068655c1b" />
<img width="2734" height="2748" alt="image" src="https://github.com/user-attachments/assets/ab44f913-d68e-43f3-95de-8f156c948a6f" />
<img width="2644" height="2752" alt="image" src="https://github.com/user-attachments/assets/9018c41d-d961-4f63-9366-49cb9f2aa2a6" />
