### PR TITLE
polish: notification ui

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -8,44 +8,81 @@ import UserAvatar from '@components/UserAvatar';
 import { UnreadDot } from '@components/ui';
 import { triggerHaptic } from '@services/haptics';
 import { colors, spacing, typography } from '@theme/index';
+import { ChatGroup, InboxItem, JoinGroup } from '@utils/notificationCollapse';
+import {
+  buildChatGroupDisplay,
+  buildJoinGroupDisplay,
+  buildNotificationDisplay,
+  chatGroupPlainText,
+  joinGroupPlainText,
+  notificationPlainText,
+} from '@utils/notificationDisplay';
 import { formatCompactRelativeTime } from '@utils/relativeTime';
 
 export interface NotificationRowProps {
-  notification: AppNotification;
-  onPress: (notification: AppNotification) => void;
+  item: InboxItem;
+  onPressSingle: (notification: AppNotification) => void;
+  onPressChatGroup: (group: ChatGroup) => void;
+  onPressJoinGroup: (group: JoinGroup) => void;
   nowMs: number;
+  /** Event cover for rows with an associated event (singles + join groups). */
   eventImageUri?: string;
-  isLast?: boolean;
 }
 
 /**
- * NotificationRow mirrors the MessagesScreen ConversationRow layout and
- * styles exactly so the inbox list looks identical to the chat list:
- * 52×52 circular avatar/cover, blue unread dot at the left edge,
- * semibold for unread, thin divider after every row.
- *
- * Shows the event cover image when the notification has an associated event
- * (same as ConversationRow); falls back to a UserAvatar otherwise.
+ * NotificationRow: 40px circular avatar/cover, blue unread dot at the left edge,
+ * and the composed notification sentence (SemiBold spans for the event/person).
+ * Renders either a single notification or a collapsed chat group.
  */
 const NotificationRow = ({
-  notification,
-  onPress,
+  item,
+  onPressSingle,
+  onPressChatGroup,
+  onPressJoinGroup,
   nowMs,
   eventImageUri,
-  isLast,
 }: NotificationRowProps) => {
-  const hasUnread = !notification.read;
-  const timestampLabel = formatCompactRelativeTime(notification.createdAt, nowMs);
+  const hasUnread = item.kind === 'single' ? !item.notification.read : true;
+  const timestampLabel = formatCompactRelativeTime(item.createdAt, nowMs);
+
+  let segments;
+  let a11yLabel: string;
+  let avatarName: string;
+  let avatarSeed: number;
+  if (item.kind === 'chatGroup') {
+    segments = buildChatGroupDisplay(item.group).segments;
+    a11yLabel = chatGroupPlainText(item.group);
+    avatarName = item.group.eventName;
+    avatarSeed = item.group.conversationId;
+  } else if (item.kind === 'joinGroup') {
+    segments = buildJoinGroupDisplay(item.group).segments;
+    a11yLabel = joinGroupPlainText(item.group);
+    avatarName = item.group.eventName;
+    avatarSeed = item.group.eventId;
+  } else {
+    segments = buildNotificationDisplay(item.notification).segments;
+    a11yLabel = notificationPlainText(item.notification);
+    avatarName = item.notification.title;
+    avatarSeed = item.notification.id;
+  }
+
+  const handlePress = () => {
+    triggerHaptic('light');
+    if (item.kind === 'chatGroup') {
+      onPressChatGroup(item.group);
+    } else if (item.kind === 'joinGroup') {
+      onPressJoinGroup(item.group);
+    } else {
+      onPressSingle(item.notification);
+    }
+  };
 
   return (
     <ScalePressable
-      onPress={() => {
-        triggerHaptic('light');
-        onPress(notification);
-      }}
+      onPress={handlePress}
       delay={80}
       accessibilityRole="button"
-      accessibilityLabel={notification.title}
+      accessibilityLabel={a11yLabel}
       style={styles.row}
     >
       {hasUnread && <UnreadDot style={styles.unreadDot} />}
@@ -59,35 +96,36 @@ const NotificationRow = ({
               transition={150}
             />
           ) : (
-            <UserAvatar name={notification.title} seed={notification.id} size={52} />
+            <UserAvatar name={avatarName} seed={avatarSeed} size={40} />
           )}
         </View>
         <View style={styles.copyInner}>
           <View style={styles.titleRow}>
             <Text
-              style={[styles.title, hasUnread && styles.titleUnread]}
-              numberOfLines={1}
+              style={[styles.message, !hasUnread && styles.messageRead]}
+              numberOfLines={3}
+              ellipsizeMode="tail"
             >
-              {notification.title}
+              {segments.map((segment, index) => (
+                <Text
+                  key={index}
+                  style={[
+                    segment.bold ? styles.messageBold : undefined,
+                    segment.muted && hasUnread ? styles.messagePreview : undefined,
+                  ]}
+                >
+                  {segment.text}
+                </Text>
+              ))}
             </Text>
             {timestampLabel ? (
-              <Text
-                style={[styles.timestamp, hasUnread && styles.timestampUnread]}
-                numberOfLines={1}
-              >
+              <Text style={styles.timestamp} numberOfLines={1}>
                 {timestampLabel}
               </Text>
             ) : null}
           </View>
-          <Text
-            style={[styles.body, hasUnread && styles.bodyUnread]}
-            numberOfLines={2}
-          >
-            {notification.body}
-          </Text>
         </View>
       </View>
-      {!isLast && <View style={styles.divider} />}
     </ScalePressable>
   );
 };
@@ -102,6 +140,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingLeft: spacing.md,
+    // 10 = the header ⋯ icon's inset inside its 44px button ((44-24)/2), so the
+    // timestamp's right edge lines up with the ⋯ icon above it.
+    paddingRight: 10,
   },
   unreadDot: {
     position: 'absolute',
@@ -110,9 +151,9 @@ const styles = StyleSheet.create({
     marginTop: -4,
   },
   avatar: {
-    width: 52,
-    height: 52,
-    borderRadius: 26,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 12,
@@ -127,52 +168,46 @@ const styles = StyleSheet.create({
     flex: 1,
     minWidth: 0,
     gap: 4,
-    paddingVertical: spacing.md,
+    // 12 (not md/16) → ~24px between rows, a tighter inbox rhythm than the
+    // MessagesScreen row this was cloned from (notifications carry more text).
+    paddingVertical: spacing.sm + spacing.xs,
   },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
   },
-  title: {
+  // Composed sentence: 15px Regular, with SemiBold spans for the event/person.
+  message: {
     flex: 1,
-    fontSize: 17,
+    fontSize: 15,
     lineHeight: 20,
-    letterSpacing: -0.5,
+    letterSpacing: -0.4,
     color: colors.text,
-    fontFamily: typography.fontFamilyMedium,
+    fontFamily: typography.fontFamilyRegular,
   },
-  titleUnread: {
+  messageBold: {
     fontFamily: typography.fontFamilySemiBold,
+  },
+  // Read rows read "quieter": the whole sentence (incl. its SemiBold spans, which
+  // inherit this color) softens from near-black to a medium grey. The blue dot
+  // stays the primary unread flag; the avatar/cover keep full strength.
+  messageRead: {
+    color: colors.cardMeta,
+  },
+  // Inline chat preview ("Sender: “message”") — dark grey, one step off black so
+  // the message reads as a quieted preview without competing with the header.
+  messagePreview: {
+    color: colors.muted,
   },
   timestamp: {
     marginLeft: spacing.sm,
     fontSize: 13,
     lineHeight: 16,
     letterSpacing: -0.2,
-    color: '#8B8B8B',
+    color: '#8B8B8B', // same as the chat list timestamp
     fontFamily: typography.fontFamilyRegular,
     textAlign: 'right',
-  },
-  timestampUnread: {
-    color: '#5E5E5E',
-    fontFamily: typography.fontFamilyMedium,
-  },
-  body: {
-    fontSize: 15,
-    lineHeight: 20,
-    letterSpacing: -0.5,
-    color: '#707070',
-    fontFamily: typography.fontFamilyRegular,
-  },
-  bodyUnread: {
-    color: colors.text,
-    fontFamily: typography.fontFamilyMedium,
-  },
-  divider: {
-    height: 1,
-    backgroundColor: colors.divider,
-    marginLeft: spacing.md + 52 + 12,
   },
 });
 

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   ActivityIndicator,
-  FlatList,
   InteractionManager,
   Pressable,
   RefreshControl,
+  SectionList,
   StyleSheet,
+  Text,
   View,
 } from 'react-native';
 
@@ -28,9 +29,11 @@ import { useNotifications } from '@context/NotificationsContext';
 import { routeFromNotification, PushData } from '@context/pushRouting';
 import { navigationRef } from '@navigation/navigationRef';
 import { RootStackParamList } from '@navigation/types';
+import { ChatGroup, InboxItem, JoinGroup, collapseNotifications } from '@utils/notificationCollapse';
+import { groupNotificationsByDate } from '@utils/notificationSections';
 import { triggerHaptic } from '@services/haptics';
 import { logger } from '@services/logger';
-import { colors, layout, spacing } from '@theme/index';
+import { colors, layout, spacing, typography } from '@theme/index';
 import { getNextCompactRelativeTimeUpdateMs } from '@utils/relativeTime';
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -64,6 +67,28 @@ const NotificationsScreen = () => {
   const { events } = useEvents();
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [menuVisible, setMenuVisible] = useState(false);
+  // Collapse chat messages per conversation, then bucket into time sections.
+  const inboxItems = useMemo(() => collapseNotifications(notifications), [notifications]);
+  // Event cover for singles + join groups (chat groups fall back to a monogram).
+  const resolveEventImageUri = useCallback(
+    (item: InboxItem): string | undefined => {
+      let eventId: number | undefined;
+      if (item.kind === 'single') {
+        eventId = item.notification.eventId ?? undefined;
+      } else if (item.kind === 'joinGroup') {
+        eventId = item.group.eventId;
+      }
+      if (eventId == null) {
+        return undefined;
+      }
+      return events.find((event) => Number(event.id) === eventId)?.imageUri;
+    },
+    [events],
+  );
+  const sections = useMemo(
+    () => groupNotificationsByDate(inboxItems, nowMs),
+    [inboxItems, nowMs],
+  );
 
   // Reload page 1 + count whenever the inbox is focused so it's fresh on open.
   useFocusEffect(
@@ -108,6 +133,46 @@ const NotificationsScreen = () => {
     [markRead, setActiveConversation],
   );
 
+  // Tapping a collapsed group: route, then mark all of the group's underlying
+  // notifications read (so the row clears).
+  const markGroupRead = useCallback(
+    (ids: number[]) => {
+      InteractionManager.runAfterInteractions(() => {
+        ids.forEach((id) => markRead(id).catch(() => undefined));
+      });
+    },
+    [markRead],
+  );
+
+  const handleChatGroupPress = useCallback(
+    (group: ChatGroup) => {
+      routeFromNotification(
+        { type: 'chat.message', conversationId: String(group.conversationId) },
+        setActiveConversation,
+        navigationRef,
+      );
+      markGroupRead(group.ids);
+    },
+    [markGroupRead, setActiveConversation],
+  );
+
+  const handleJoinGroupPress = useCallback(
+    (group: JoinGroup) => {
+      routeFromNotification(
+        {
+          type: 'join_request.created',
+          eventId: String(group.eventId),
+          conversationId: group.conversationId != null ? String(group.conversationId) : undefined,
+          title: group.eventName,
+        },
+        setActiveConversation,
+        navigationRef,
+      );
+      markGroupRead(group.ids);
+    },
+    [markGroupRead, setActiveConversation],
+  );
+
   const handleMarkAllRead = useCallback(() => {
     setMenuVisible(false);
     if (unreadCount === 0) return;
@@ -123,7 +188,8 @@ const NotificationsScreen = () => {
 
   const showInitialLoading = loading && notifications.length === 0 && !refreshing;
   const showError = !!error && !loading && notifications.length === 0;
-  const showEmpty = !loading && notifications.length === 0 && !error;
+  // Empty when nothing is left to show after collapse (e.g. all chat rows read).
+  const showEmpty = !loading && inboxItems.length === 0 && !error;
 
   const menuActions = [
     {
@@ -180,23 +246,25 @@ const NotificationsScreen = () => {
           </Pressable>
         </View>
       ) : (
-        <FlatList
-          data={notifications}
-          keyExtractor={(item) => String(item.id)}
-          renderItem={({ item, index }) => (
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => item.key}
+          renderItem={({ item }) => (
             <NotificationRow
-              notification={item}
-              onPress={handleRowPress}
+              item={item}
+              onPressSingle={handleRowPress}
+              onPressChatGroup={handleChatGroupPress}
+              onPressJoinGroup={handleJoinGroupPress}
               nowMs={nowMs}
-              isLast={index === notifications.length - 1}
-              eventImageUri={
-                item.eventId != null
-                  ? events.find((event) => Number(event.id) === item.eventId)?.imageUri
-                  : undefined
-              }
+              eventImageUri={resolveEventImageUri(item)}
             />
           )}
+          renderSectionHeader={({ section }) => (
+            <Text style={styles.sectionHeader}>{section.title}</Text>
+          )}
+          stickySectionHeadersEnabled={false}
           style={styles.list}
+          showsVerticalScrollIndicator={false}
           contentContainerStyle={[
             showEmpty ? styles.emptyList : styles.listContent,
             { paddingBottom: spacing.xl + safeBottom },
@@ -282,6 +350,20 @@ const styles = StyleSheet.create({
   },
   listContent: {
     flexGrow: 1,
+    // Restore the first section's original distance from the title bar, since
+    // sectionHeader.marginTop is now reduced for the between-section gaps.
+    paddingTop: spacing.sm,
+  },
+  // Time-section header — matches the Discover event-list section headers.
+  sectionHeader: {
+    paddingLeft: spacing.md, // align with the row avatars
+    marginTop: spacing.sm,
+    marginBottom: spacing.sm,
+    fontSize: 15,
+    lineHeight: typography.body + spacing.xs,
+    letterSpacing: typography.detailLetterSpacing,
+    color: colors.cardMeta,
+    fontFamily: typography.fontFamilyMedium,
   },
   emptyList: {
     flex: 1,

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -419,13 +419,15 @@ const styles = StyleSheet.create({
     // button container, so it visually sits on the bell's upper-right.
     top: 10,
     right: 11,
-    // White ring around the dot. RN draws borders inside the box, so bump the
-    // size to 12 (8px blue fill + 2px ring on each side) to keep the blue 8px.
-    width: 12,
-    height: 12,
-    borderRadius: 6,
+    // Match the chat tab-bar unread dot: red fill with a white ring. RN draws
+    // borders inside the box, so 10px outer (6px red fill + 2px ring each side)
+    // keeps it the same size as the chat dot.
+    width: 10,
+    height: 10,
+    borderRadius: 5,
     borderWidth: 2,
     borderColor: colors.background,
+    backgroundColor: colors.tabBarUnreadDot,
   },
   headerTitle: {
     fontSize: typography.header,

--- a/src/screens/__tests__/NotificationsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/NotificationsScreen.rendering.test.tsx
@@ -132,8 +132,9 @@ const sampleNotifications = (): AppNotification[] => [
     id: 1,
     type: 'chat.message',
     conversationId: 10,
-    title: 'Alice',
+    title: 'Dancing',
     body: 'Alice: hey',
+    payload: JSON.stringify({ senderName: 'Alice' }),
     read: false,
     createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
   },
@@ -213,7 +214,7 @@ describe('NotificationsScreen Rendering', () => {
     expect(mockClearAll).toHaveBeenCalledTimes(1);
   });
 
-  it('renders notification rows with title, body, and unread dot', () => {
+  it('renders the composed notification copy and unread dot', () => {
     mockNotificationsValue = {
       ...mockNotificationsValue,
       notifications: sampleNotifications(),
@@ -221,9 +222,11 @@ describe('NotificationsScreen Rendering', () => {
     };
     const { getByText } = render(<NotificationsScreen />);
 
-    expect(getByText('Alice: hey')).toBeTruthy();
+    // Chat: composed sentence with the message preview inline.
+    expect(getByText('New message from Alice in Dancing: hey')).toBeTruthy();
+    // Declined: event name leads the softened sentence.
     expect(
-      getByText('This event is no longer available to you. Explore other events nearby.'),
+      getByText('Hike is no longer available to you. Explore other events nearby.'),
     ).toBeTruthy();
   });
 
@@ -247,7 +250,7 @@ describe('NotificationsScreen Rendering', () => {
     const { getByLabelText } = render(<NotificationsScreen />);
 
     await act(async () => {
-      fireEvent.press(getByLabelText('Alice'));
+      fireEvent.press(getByLabelText(/New message from Alice/));
     });
 
     expect(mockMarkRead).toHaveBeenCalledWith(1);
@@ -264,7 +267,7 @@ describe('NotificationsScreen Rendering', () => {
     const { getByLabelText } = render(<NotificationsScreen />);
 
     await act(async () => {
-      fireEvent.press(getByLabelText('Hike'));
+      fireEvent.press(getByLabelText(/Hike is no longer available/));
     });
 
     // Read row => markRead NOT called for id 2.
@@ -284,7 +287,7 @@ describe('NotificationsScreen Rendering', () => {
     const { getByLabelText } = render(<NotificationsScreen />);
 
     await act(async () => {
-      fireEvent.press(getByLabelText('Alice'));
+      fireEvent.press(getByLabelText(/New message from Alice/));
     });
 
     expect(mockSetActiveConversation).toHaveBeenCalledWith(10);

--- a/src/utils/__tests__/notificationCollapse.test.ts
+++ b/src/utils/__tests__/notificationCollapse.test.ts
@@ -1,0 +1,210 @@
+import { AppNotification } from '@api/mappers/notifications';
+import { collapseNotifications } from '@utils/notificationCollapse';
+import { buildChatGroupDisplay, buildJoinGroupDisplay } from '@utils/notificationDisplay';
+
+const join = (
+  id: number,
+  eventId: number,
+  requester: string,
+  title: string,
+  overrides: Partial<AppNotification> = {},
+): AppNotification => ({
+  id,
+  type: 'join_request.created',
+  eventId,
+  title,
+  body: `${requester} wants to join your event`,
+  read: false,
+  createdAt: new Date(2026, 0, 1, 12, 0, id).toISOString(),
+  ...overrides,
+});
+
+const chat = (
+  id: number,
+  conversationId: number,
+  sender: string,
+  message: string,
+  overrides: Partial<AppNotification> = {},
+): AppNotification => ({
+  id,
+  type: 'chat.message',
+  conversationId,
+  title: 'Dancing',
+  body: `${sender}: ${message}`,
+  payload: JSON.stringify({ senderName: sender }),
+  read: false,
+  createdAt: new Date(2026, 0, 1, 12, 0, id).toISOString(),
+  ...overrides,
+});
+
+const groupText = (segments: { text: string }[]) => segments.map((s) => s.text).join('');
+
+describe('collapseNotifications', () => {
+  it('collapses unread chat messages per conversation into one group', () => {
+    const items = collapseNotifications([
+      chat(3, 10, 'Sylvie', 'see you'),
+      chat(2, 10, 'Sylvie', 'you there'),
+      chat(1, 10, 'Sylvie', 'hi'),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe('chatGroup');
+    if (items[0].kind === 'chatGroup') {
+      expect(items[0].group.count).toBe(3);
+      expect(items[0].group.ids).toEqual([3, 2, 1]);
+      expect(items[0].group.latestPreview).toBe('see you'); // latest = first (newest-first input)
+      expect(items[0].group.senderNames).toEqual(['Sylvie']);
+    }
+  });
+
+  it('keeps separate conversations as separate groups', () => {
+    const items = collapseNotifications([
+      chat(2, 10, 'Sylvie', 'hi', { title: 'Dancing' }),
+      chat(1, 20, 'Joe', 'yo', { title: 'Hiking' }),
+    ]);
+    expect(items).toHaveLength(2);
+  });
+
+  it('drops read chat notifications entirely', () => {
+    const items = collapseNotifications([
+      chat(2, 10, 'Sylvie', 'hi'),
+      chat(1, 10, 'Sylvie', 'old', { read: true }),
+    ]);
+    expect(items).toHaveLength(1);
+    if (items[0].kind === 'chatGroup') {
+      expect(items[0].group.count).toBe(1);
+      expect(items[0].group.ids).toEqual([2]);
+    }
+  });
+
+  it('lists unique senders, latest first', () => {
+    const items = collapseNotifications([
+      chat(3, 10, 'Sylvie', 'c'),
+      chat(2, 10, 'Joe', 'b'),
+      chat(1, 10, 'Sylvie', 'a'),
+    ]);
+    if (items[0].kind === 'chatGroup') {
+      expect(items[0].group.senderNames).toEqual(['Sylvie', 'Joe']);
+    }
+  });
+
+  it('collapses join requests per event, and keeps chat separate', () => {
+    const items = collapseNotifications([
+      join(3, 1, 'Sylvie', 'Dancing'),
+      join(2, 1, 'Joe', 'Dancing'),
+      chat(1, 10, 'Sylvie', 'hi'),
+    ]);
+    expect(items).toHaveLength(2);
+    const joinItem = items.find((i) => i.kind === 'joinGroup');
+    expect(joinItem?.kind).toBe('joinGroup');
+    if (joinItem?.kind === 'joinGroup') {
+      expect(joinItem.group.count).toBe(2);
+      expect(joinItem.group.requesterNames).toEqual(['Sylvie', 'Joe']);
+    }
+  });
+
+  it('separates join requests for different events', () => {
+    const items = collapseNotifications([
+      join(2, 1, 'Sylvie', 'Dancing'),
+      join(1, 2, 'Joe', 'Hiking'),
+    ]);
+    expect(items).toHaveLength(2);
+  });
+
+  it('drops read join requests', () => {
+    const items = collapseNotifications([
+      join(2, 1, 'Sylvie', 'Dancing'),
+      join(1, 1, 'Joe', 'Dancing', { read: true }),
+    ]);
+    if (items[0].kind === 'joinGroup') {
+      expect(items[0].group.count).toBe(1);
+    }
+  });
+
+  it('passes unknown notification types through individually', () => {
+    const approved: AppNotification = {
+      id: 5,
+      type: 'join_request.approved',
+      eventId: 1,
+      title: 'Dancing',
+      body: 'Your request to join was approved!',
+      read: false,
+      createdAt: new Date(2026, 0, 1, 12, 0, 5).toISOString(),
+    };
+    const items = collapseNotifications([approved, chat(1, 10, 'Sylvie', 'hi')]);
+    expect(items).toHaveLength(2);
+    expect(items[0].kind).toBe('single');
+    expect(items[1].kind).toBe('chatGroup');
+  });
+});
+
+describe('buildJoinGroupDisplay copy', () => {
+  const group = (count: number, requesterNames: string[]) => ({
+    eventId: 1,
+    eventName: 'Dancing',
+    requesterNames,
+    count,
+    createdAt: new Date().toISOString(),
+    ids: [],
+  });
+
+  it('singular "wants" for one requester', () => {
+    expect(groupText(buildJoinGroupDisplay(group(1, ['Sylvie'])).segments)).toBe(
+      'Sylvie wants to join your event Dancing',
+    );
+  });
+
+  it('plural "want" + name list for multiple requesters', () => {
+    expect(groupText(buildJoinGroupDisplay(group(3, ['Sylvie', 'Joe', 'Amy'])).segments)).toBe(
+      'Sylvie, Joe & 1 other want to join your event Dancing',
+    );
+  });
+});
+
+describe('buildChatGroupDisplay copy', () => {
+  const group = (count: number, senderNames: string[]) => ({
+    conversationId: 10,
+    eventName: 'Dancing',
+    senderNames,
+    count,
+    latestSender: senderNames[0] ?? '',
+    latestPreview: 'See you at 7 pm',
+    createdAt: new Date().toISOString(),
+    ids: [],
+  });
+
+  it('singular for one message', () => {
+    expect(groupText(buildChatGroupDisplay(group(1, ['Sylvie'])).segments)).toBe(
+      'New message from Sylvie in Dancing. Sylvie: See you at 7 pm',
+    );
+  });
+
+  it('plural for multiple messages', () => {
+    expect(groupText(buildChatGroupDisplay(group(3, ['Sylvie'])).segments)).toBe(
+      'New messages from Sylvie in Dancing. Sylvie: See you at 7 pm',
+    );
+  });
+
+  it('leads with the latest sender + "& 1 other" for two senders', () => {
+    expect(groupText(buildChatGroupDisplay(group(2, ['Sylvie', 'Joe'])).segments)).toBe(
+      'New messages from Sylvie & 1 other in Dancing. Sylvie: See you at 7 pm',
+    );
+  });
+
+  it('leads with the latest sender + "& 2 others" for three senders', () => {
+    expect(groupText(buildChatGroupDisplay(group(3, ['Sylvie', 'Joe', 'Amy'])).segments)).toBe(
+      'New messages from Sylvie & 2 others in Dancing. Sylvie: See you at 7 pm',
+    );
+  });
+
+  it('leads with the latest sender + "& N others" for four+ senders', () => {
+    expect(
+      groupText(buildChatGroupDisplay(group(4, ['Sylvie', 'Joe', 'Amy', 'Max'])).segments),
+    ).toBe('New messages from Sylvie & 3 others in Dancing. Sylvie: See you at 7 pm');
+  });
+
+  it('renders the preview inline as "Sender: “message”" in the last segment', () => {
+    const segments = buildChatGroupDisplay(group(1, ['Sylvie'])).segments;
+    expect(segments[segments.length - 1].text).toBe('Sylvie: See you at 7 pm');
+  });
+});

--- a/src/utils/notificationCollapse.ts
+++ b/src/utils/notificationCollapse.ts
@@ -1,0 +1,182 @@
+/**
+ * Collapses the raw notification list into inbox rows (visual collapse, no
+ * backend):
+ *
+ *  - Unread `chat.message` notifications collapse per CONVERSATION into one row.
+ *  - Unread `join_request.created` notifications collapse per EVENT into one row
+ *    (works for both 1:1 and group events — requests are per-event).
+ *  - Read notifications of those two types are dropped (once handled, they're
+ *    done — the chat / Join Requests screen is the source of truth).
+ *  - Every other notification passes through individually.
+ *
+ * Input is assumed newest-first; a group is positioned at its latest member, so
+ * the overall order stays newest-first.
+ */
+import { AppNotification } from '@api/mappers/notifications';
+
+export type ChatGroup = {
+  conversationId: number;
+  /** Event/conversation name (from the latest notification's title). */
+  eventName: string;
+  /** Unique sender first-names, latest first. */
+  senderNames: string[];
+  /** Number of unread messages combined. */
+  count: number;
+  /** First-name of the latest message's sender, for the "Sender: message" preview. */
+  latestSender: string;
+  /** Latest message body (already stripped of the "Sender: " prefix). */
+  latestPreview: string;
+  createdAt: string;
+  /** All underlying notification ids (marked read together on tap). */
+  ids: number[];
+};
+
+export type JoinGroup = {
+  eventId: number;
+  /** Conversation for routing to the Join Requests screen (from the latest). */
+  conversationId?: number;
+  eventName: string;
+  /** Unique requester first-names, latest first. */
+  requesterNames: string[];
+  count: number;
+  createdAt: string;
+  ids: number[];
+};
+
+export type InboxItem =
+  | { kind: 'single'; key: string; createdAt: string; notification: AppNotification }
+  | { kind: 'chatGroup'; key: string; createdAt: string; group: ChatGroup }
+  | { kind: 'joinGroup'; key: string; createdAt: string; group: JoinGroup };
+
+const firstName = (name: string): string => name.split(' ')[0] || name;
+
+const parseSender = (n: AppNotification): string => {
+  if (n.payload) {
+    try {
+      const p = JSON.parse(n.payload);
+      if (p && typeof p.senderName === 'string' && p.senderName) {
+        return p.senderName;
+      }
+    } catch {
+      // fall through to body parsing
+    }
+  }
+  const idx = n.body.indexOf(':'); // body is "Sender: message"
+  return idx > 0 ? n.body.slice(0, idx).trim() : '';
+};
+
+const parsePreview = (n: AppNotification, sender: string): string => {
+  const prefix = `${sender}: `;
+  return n.body.startsWith(prefix) ? n.body.slice(prefix.length) : n.body;
+};
+
+const JOIN_SUFFIX = ' wants to join your event';
+
+const parseRequester = (n: AppNotification): string =>
+  n.body.endsWith(JOIN_SUFFIX) ? n.body.slice(0, -JOIN_SUFFIX.length).trim() : n.body.trim();
+
+const conversationIdFromPayload = (n: AppNotification): number | undefined => {
+  if (n.conversationId != null) {
+    return n.conversationId;
+  }
+  if (n.payload) {
+    try {
+      const p = JSON.parse(n.payload);
+      const cid = Number(p?.conversationId);
+      return Number.isFinite(cid) ? cid : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+const addUnique = (names: string[], name: string) => {
+  if (name && !names.includes(name)) {
+    names.push(name);
+  }
+};
+
+export const collapseNotifications = (notifications: AppNotification[]): InboxItem[] => {
+  const items: InboxItem[] = [];
+  const chatIndexByConvo = new Map<number, number>();
+  const joinIndexByEvent = new Map<number, number>();
+
+  for (const n of notifications) {
+    // ── Chat messages: collapse per conversation (unread only) ──
+    if (n.type === 'chat.message') {
+      if (n.read) {
+        continue;
+      }
+      const convoId = n.conversationId;
+      if (convoId == null) {
+        items.push({ kind: 'single', key: `n-${n.id}`, createdAt: n.createdAt, notification: n });
+        continue;
+      }
+      const sender = firstName(parseSender(n));
+      const existing = chatIndexByConvo.get(convoId);
+      if (existing == null) {
+        const group: ChatGroup = {
+          conversationId: convoId,
+          eventName: n.title,
+          senderNames: sender ? [sender] : [],
+          count: 1,
+          latestSender: sender,
+          latestPreview: parsePreview(n, parseSender(n)),
+          createdAt: n.createdAt,
+          ids: [n.id],
+        };
+        chatIndexByConvo.set(convoId, items.length);
+        items.push({ kind: 'chatGroup', key: `c-${convoId}`, createdAt: n.createdAt, group });
+      } else {
+        const item = items[existing];
+        if (item.kind === 'chatGroup') {
+          item.group.count += 1;
+          item.group.ids.push(n.id);
+          addUnique(item.group.senderNames, sender);
+        }
+      }
+      continue;
+    }
+
+    // ── Join requests: collapse per event (unread only) ──
+    if (n.type === 'join_request.created') {
+      if (n.read) {
+        continue;
+      }
+      const eventId = n.eventId;
+      if (eventId == null) {
+        items.push({ kind: 'single', key: `n-${n.id}`, createdAt: n.createdAt, notification: n });
+        continue;
+      }
+      const requester = firstName(parseRequester(n));
+      const existing = joinIndexByEvent.get(eventId);
+      if (existing == null) {
+        const group: JoinGroup = {
+          eventId,
+          conversationId: conversationIdFromPayload(n),
+          eventName: n.title,
+          requesterNames: requester ? [requester] : [],
+          count: 1,
+          createdAt: n.createdAt,
+          ids: [n.id],
+        };
+        joinIndexByEvent.set(eventId, items.length);
+        items.push({ kind: 'joinGroup', key: `j-${eventId}`, createdAt: n.createdAt, group });
+      } else {
+        const item = items[existing];
+        if (item.kind === 'joinGroup') {
+          item.group.count += 1;
+          item.group.ids.push(n.id);
+          addUnique(item.group.requesterNames, requester);
+        }
+      }
+      continue;
+    }
+
+    // ── Everything else: individual row ──
+    items.push({ kind: 'single', key: `n-${n.id}`, createdAt: n.createdAt, notification: n });
+  }
+
+  return items;
+};

--- a/src/utils/notificationDisplay.ts
+++ b/src/utils/notificationDisplay.ts
@@ -1,0 +1,183 @@
+/**
+ * Builds the single-line notification-inbox copy as styled segments.
+ *
+ * The notification page composes its own display sentence per type from the
+ * event name (`title`), and — for the person-driven types — the actor name
+ * (from the push `payload.senderName`, or parsed from the server body). Segments
+ * flagged `bold` render SemiBold; the rest Regular. Chat rows additionally
+ * return a `preview` (the message text) shown on a second line.
+ */
+import { AppNotification } from '@api/mappers/notifications';
+import { ChatGroup, JoinGroup } from '@utils/notificationCollapse';
+
+export type NotificationSegment = { text: string; bold?: boolean; muted?: boolean };
+
+export type NotificationDisplay = {
+  segments: NotificationSegment[];
+};
+
+/** Flattens the display copy to a plain string (used for the row's a11y label). */
+export const notificationPlainText = (notification: AppNotification): string =>
+  buildNotificationDisplay(notification)
+    .segments.map((segment) => segment.text)
+    .join('');
+
+/**
+ * Builds the copy for a collapsed chat group. Leads with the latest sender:
+ *   1 sender  → "Sylvie"
+ *   2 senders → "Sylvie, Joe"
+ *   3+        → "Sylvie, Joe & N others" (N = count − 2, singular "& 1 other")
+ * "message"/"messages" pluralizes on the combined count.
+ */
+const formatSenderNames = (names: string[]): string => {
+  if (names.length <= 1) {
+    return names[0] ?? '';
+  }
+  if (names.length === 2) {
+    return `${names[0]}, ${names[1]}`;
+  }
+  const others = names.length - 2;
+  return `${names[0]}, ${names[1]} & ${others} other${others === 1 ? '' : 's'}`;
+};
+
+export const buildChatGroupDisplay = (group: ChatGroup): NotificationDisplay => {
+  // Lead with the latest sender only (the same person shown in the preview line);
+  // collapse everyone else into "& N other(s)" so the header never grows a list.
+  const latest = group.senderNames[0] ?? '';
+  const others = group.senderNames.length - 1;
+  const senders = others > 0 ? `${latest} & ${others} other${others === 1 ? '' : 's'}` : latest;
+  const messageWord = group.count > 1 ? 'messages' : 'message';
+  // Preview reads "Sender: message" inline after the header, in a dark grey.
+  const preview = group.latestSender
+    ? `${group.latestSender}: ${group.latestPreview}`
+    : group.latestPreview;
+  return {
+    segments: [
+      { text: `New ${messageWord} from `, bold: false },
+      { text: senders, bold: true },
+      { text: ' in ', bold: false },
+      { text: group.eventName, bold: true },
+      { text: '. ', bold: false },
+      { text: preview, bold: false, muted: true },
+    ],
+  };
+};
+
+export const chatGroupPlainText = (group: ChatGroup): string =>
+  buildChatGroupDisplay(group)
+    .segments.map((segment) => segment.text)
+    .join('');
+
+/**
+ * Builds the copy for a collapsed join-request group (per event):
+ *   "Sylvie wants to join your event Dancing"
+ *   "Sylvie, Joe & 2 others want to join your event Dancing"
+ * (verb agrees: "wants" for one requester, "want" for many).
+ */
+export const buildJoinGroupDisplay = (group: JoinGroup): NotificationDisplay => {
+  const requesters = formatSenderNames(group.requesterNames);
+  const verb = group.requesterNames.length > 1 ? 'want' : 'wants';
+  return {
+    segments: [
+      { text: requesters, bold: true },
+      { text: ` ${verb} to join your event `, bold: false },
+      { text: group.eventName, bold: true },
+    ],
+  };
+};
+
+export const joinGroupPlainText = (group: JoinGroup): string =>
+  buildJoinGroupDisplay(group)
+    .segments.map((segment) => segment.text)
+    .join('');
+
+const parsePayload = (payload?: string): Record<string, string> => {
+  if (!payload) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(payload);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+const JOIN_CREATED_SUFFIX = ' wants to join your event';
+
+export const buildNotificationDisplay = (notification: AppNotification): NotificationDisplay => {
+  const eventName = notification.title;
+  const payload = parsePayload(notification.payload);
+
+  switch (notification.type) {
+    case 'chat.message': {
+      const senderName = payload.senderName || notification.body.split(':')[0].trim();
+      const prefix = `${senderName}: `;
+      const preview = notification.body.startsWith(prefix)
+        ? notification.body.slice(prefix.length)
+        : notification.body;
+      return {
+        segments: [
+          { text: 'New message from ', bold: false },
+          { text: senderName, bold: true },
+          { text: ' in ', bold: false },
+          { text: eventName, bold: true },
+          { text: '. ', bold: false },
+          // The message itself, inline, in a dark grey (colors.muted).
+          { text: `${senderName}: ${preview}`, bold: false, muted: true },
+        ],
+      };
+    }
+
+    case 'join_request.created': {
+      const actor = notification.body.endsWith(JOIN_CREATED_SUFFIX)
+        ? notification.body.slice(0, -JOIN_CREATED_SUFFIX.length)
+        : payload.senderName || '';
+      return {
+        segments: [
+          { text: actor, bold: true },
+          { text: ' wants to join your event ', bold: false },
+          { text: eventName, bold: true },
+        ],
+      };
+    }
+
+    case 'join_request.approved':
+      return {
+        segments: [
+          { text: 'Your request to join ', bold: false },
+          { text: eventName, bold: true },
+          { text: ' has been approved!', bold: false },
+        ],
+      };
+
+    case 'join_request.denied':
+      return {
+        segments: [
+          { text: eventName, bold: true },
+          { text: ' is no longer available to you. Explore other events nearby.', bold: false },
+        ],
+      };
+
+    case 'event.member_removed':
+      return {
+        segments: [
+          { text: 'You no longer have access to ', bold: false },
+          { text: eventName, bold: true },
+          { text: '. Explore other events nearby.', bold: false },
+        ],
+      };
+
+    case 'event.deleted':
+      return {
+        segments: [
+          { text: eventName, bold: true },
+          { text: ' has been cancelled and is no longer happening.', bold: false },
+        ],
+      };
+
+    default:
+      // Unknown type: render the server body verbatim so the inbox never breaks.
+      return { segments: [{ text: notification.body, bold: false }] };
+  }
+};

--- a/src/utils/notificationSections.ts
+++ b/src/utils/notificationSections.ts
@@ -1,0 +1,61 @@
+/**
+ * Buckets inbox items into widening time windows
+ * (Today / Last 7 Days / Last 30 Days / Earlier).
+ *
+ * Assumes the input is already ordered newest-first; order is preserved within
+ * each section, and empty sections are omitted.
+ */
+import { InboxItem } from '@utils/notificationCollapse';
+
+export type NotificationSection = {
+  title: string;
+  data: InboxItem[];
+};
+
+const startOfDay = (ms: number): number => {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const sectionTitleForDayDiff = (diffDays: number): string => {
+  if (diffDays <= 0) {
+    return 'Today';
+  }
+  if (diffDays <= 7) {
+    return 'Last 7 Days';
+  }
+  if (diffDays <= 30) {
+    return 'Last 30 Days';
+  }
+  return 'Earlier';
+};
+
+export const groupNotificationsByDate = (
+  items: InboxItem[],
+  nowMs: number,
+): NotificationSection[] => {
+  const today = startOfDay(nowMs);
+  const sections: NotificationSection[] = [];
+  const byTitle = new Map<string, NotificationSection>();
+
+  for (const item of items) {
+    const created = Date.parse(item.createdAt);
+    const diffDays = Number.isNaN(created)
+      ? 0
+      : Math.round((today - startOfDay(created)) / MS_PER_DAY);
+    const title = sectionTitleForDayDiff(diffDays);
+
+    let section = byTitle.get(title);
+    if (!section) {
+      section = { title, data: [] };
+      byTitle.set(title, section);
+      sections.push(section);
+    }
+    section.data.push(item);
+  }
+
+  return sections;
+};


### PR DESCRIPTION
### Change Notification UI


**Bell badge (Profile page)**
     
- Changed the unread badge on the bell icon from blue to red, matching the chat tab's unread dot.
- Resized it to match the chat dot exactly (10×10 with a 2px white ring) instead of being slightly larger.

**Notification copy / wording**

- Chat previews now show who said it: the message preview reads "Sender: message" (e.g. Sumit: I will join you) instead of just the message text.
- Group headers lead with the latest sender and collapse the rest: instead of listing everyone (Sumit, Joe), it now says "Sumit & 1 other" / "Sumit & 2 others". The named person is always the one whose message is shown in the preview.
- Separator changed after the event name from a colon to a full stop (…Group football. Sumit: I will join you).
- Singular vs plural confirmed correct: "New message" for one, "New messages" for more than one (based on the combined  count).

**Message length / truncation**

- The whole notification line (header + inline preview) is capped at 3 lines and truncates with an ellipsis (…) — no  more walls of text.

**Preview styling**

- Explored a few looks (light grey, quotes, a separate smaller second line) and landed on: preview stays inline on the  same line at the same font size, in a dark grey (colors.muted #595858) so the message reads as a quieted preview  without competing with the black header — no quotes.

**Read vs unread**

- Read notifications now dim: a read row's whole sentence softens from near-black to grey, while the blue unread dot  stays the primary "new" flag and the avatar/cover keep full strength.

**Time grouping**

- Added Today / Last 7 Days / Last 30 Days 

**Spacing / layout**

- Tightened row spacing — gap between rows went from ~32px to ~24px, so the list feels less floaty.
- Tightened the gap above section headers (~32px → ~20px), balanced so each header still groups with the section below it.
- Kept the first "Today" header's distance from the title bar unchanged (you liked that), by offsetting the reduced  header spacing with list top-padding.

**Collapsing (the big omission)**

- Chat messages collapse per conversation — all your unread messages in one chat combine into a single row ("New  messages from … in Dancing").
- Join requests also collapse — I didn't mention these at all. Multiple "wants to join" requests for the same event  combine into one row: "Sylvie & 2 others want to join your event Dancing", with correct verb agreement ("wants" for  one, "want" for many). Tapping it opens the Join Requests screen.
- First-name only — every name (senders and requesters) is shortened to the first name.

**Read / unread semantics (frontend)**

- Combine window = unread only. Only unread messages combine; the row is really "your unread messages in this chat,  summarized."
- Read chat & join rows drop off the list entirely. Once you open the chat (or handle the request), those collapsed  rows disappear — the chat/Join-Requests screen is the source of truth. (This is why the "read-sync" backend task  matters — until the server marks them read, the row won't auto-clear.)
- No message count shown — deliberately just a nudge ("Sylvie & 2 others"), not "· 5 new", per your call in the spec.

**Behavior**

- Rows re-sort to the top on new activity — a collapsed group sits at its latest message's position with the latest  timestamp, so a new message jumps the row up.
- Tapping a collapsed row marks all its underlying notifications read (so the whole group clears at once) and routes  to the right place.
- It's a frontend-only visual collapse — the underlying notification records are untouched, no backend change, fully  reversible. (Not server-side replacement.)

---

**After**

<img width="588" height="1272" alt="image" src="https://github.com/user-attachments/assets/730f285d-ec3f-48dd-b213-3148395110cd" />
<img width="585" height="1266" alt="Screenshot 2026-07-25 at 11 07 22 a m" src="https://github.com/user-attachments/assets/f91ed7d3-cbc7-4090-a8a1-333b8fb7898d" />
