### PR TITLE
change: avatar color from solid to gradient

### DIFF
--- a/src/components/AvatarBackground.tsx
+++ b/src/components/AvatarBackground.tsx
@@ -1,0 +1,47 @@
+import { memo } from "react";
+import { StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+import { getAvatarGradient } from "@utils/avatar";
+
+// Bleed a couple px past the frame so the gradient extends *under* any border a
+// consumer adds (e.g. ProfileScreen's 1px ring). Without this, the frame's solid
+// fallback backgroundColor shows through the translucent border as a contrasting
+// rim. The parent's overflow:hidden clips the overscan back to the circle.
+const BLEED = -2;
+
+interface AvatarBackgroundProps {
+  seed?: number | string | null;
+  name?: string | null;
+}
+
+/**
+ * Gradient fill for a no-photo avatar. Absolutely fills a rounded,
+ * overflow-hidden parent (UserAvatar frame or the profile placeholder) and
+ * renders a diagonal (top-left → bottom-right) two-stop gradient chosen
+ * deterministically from the seed.
+ */
+const AvatarBackground = ({ seed, name }: AvatarBackgroundProps) => {
+  const colors = getAvatarGradient(seed, name);
+  return (
+    <LinearGradient
+      colors={colors}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.fill}
+      pointerEvents="none"
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  fill: {
+    position: "absolute",
+    top: BLEED,
+    left: BLEED,
+    right: BLEED,
+    bottom: BLEED,
+  },
+});
+
+export default memo(AvatarBackground);

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { Image } from "expo-image";
 
+import AvatarBackground from "@components/AvatarBackground";
 import { typography } from "@theme/index";
 import {
   getAvatarColor,
@@ -61,6 +62,7 @@ const UserAvatar = ({
         />
       ) : (
         <View style={styles.initialsFrame}>
+          <AvatarBackground seed={seed} name={name} />
           <Text
             style={[styles.initials, { fontSize, lineHeight: size }, textStyle]}
             numberOfLines={1}

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -23,6 +23,7 @@ import { RootStackParamList } from '@navigation/types';
 import { triggerHaptic } from '@services/haptics';
 import CameraIcon from '@assets/onboarding/camera.svg';
 import ProfileIcon from '@assets/onboarding/profile.svg';
+import AvatarBackground from '@components/AvatarBackground';
 import { getAvatarColor } from '@utils/avatar';
 
 let ImagePicker: typeof import('expo-image-picker') | null = null;
@@ -138,6 +139,7 @@ const EditProfileScreen = () => {
             <TouchableOpacity onPress={pickImage} accessibilityRole="button">
               {!editAvatarValue && !editName.trim() ? (
                 <View style={[styles.avatarPlaceholder, { backgroundColor: avatarColor }]}>
+                  <AvatarBackground seed={user?.id} name={editName.trim() || user?.name} />
                   <ProfileIcon width={52} height={52} />
                 </View>
               ) : (
@@ -236,6 +238,7 @@ const styles = StyleSheet.create({
     borderRadius: 60,
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'hidden', // clip the gradient background to the circle
   },
   cameraBadgeShadow: {
     position: 'absolute',

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -39,6 +39,7 @@ import { RootStackParamList } from '@navigation/types';
 import { triggerHaptic } from '@services/haptics';
 import { logger } from '@services/logger';
 import { colors, typography } from '@theme/index';
+import AvatarBackground from '@components/AvatarBackground';
 import { getAvatarColor } from '@utils/avatar';
 
 // Lazy import to handle missing native module gracefully
@@ -265,6 +266,7 @@ const OnboardingScreen = () => {
                   >
                     {!avatarBase64 && !name.trim() ? (
                       <View style={[styles.avatarPlaceholder, { backgroundColor: avatarColor }]}>
+                        <AvatarBackground seed={user?.id} name={name.trim()} />
                         <ProfileIcon width={52} height={52} />
                       </View>
                     ) : (
@@ -562,6 +564,7 @@ const styles = StyleSheet.create({
     borderRadius: 60,
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'hidden', // clip the gradient background to the circle
   },
   cameraBadgeShadow: {
     position: 'absolute',

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -456,8 +456,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginBottom: spacing.md,
     overflow: 'hidden',
-    borderWidth: 1,
-    borderColor: 'rgba(0,0,0,0.1)',
   },
   name: {
     fontSize: 20,

--- a/src/utils/__tests__/avatar.test.ts
+++ b/src/utils/__tests__/avatar.test.ts
@@ -1,5 +1,6 @@
 import {
   getAvatarColor,
+  getAvatarGradient,
   getAvatarInitials,
   resolveAvatarUri,
 } from "../avatar";
@@ -49,6 +50,23 @@ describe("avatar utils", () => {
 
     it("falls back to the name when no explicit seed is provided", () => {
       expect(getAvatarColor(undefined, "Ada")).toBe(getAvatarColor(undefined, "Ada"));
+    });
+  });
+
+  describe("getAvatarGradient", () => {
+    it("is stable for the same seed", () => {
+      expect(getAvatarGradient(42)).toEqual(getAvatarGradient(42));
+      expect(getAvatarGradient("Ada")).toEqual(getAvatarGradient("Ada"));
+    });
+
+    it("falls back to the name when no explicit seed is provided", () => {
+      expect(getAvatarGradient(undefined, "Ada")).toEqual(getAvatarGradient(undefined, "Ada"));
+    });
+
+    it("resolves to a [start, end] color pair", () => {
+      const [start, end] = getAvatarGradient("someone");
+      expect(start).toMatch(/^#[0-9A-F]{6}$/i);
+      expect(end).toMatch(/^#[0-9A-F]{6}$/i);
     });
   });
 });

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -21,6 +21,24 @@ const AVATAR_COLORS = [
   "#F07878",
 ] as const;
 
+// Gradient backgrounds for no-photo avatars, as [startColor, endColor] pairs
+// (0% → 100%). Rendered diagonally by AvatarBackground. Hex values are
+// brand/artwork palette data — an allowed exception to the theme-token rule.
+const AVATAR_GRADIENTS = [
+  ["#FEC1C2", "#F83134"], // red
+  ["#F1E0C1", "#FF4010"], // orange
+  ["#F8CDEE", "#FF22C8"], // magenta
+  ["#FFFFA7", "#F2A900"], // yellow
+  ["#CDFAF0", "#00B8A0"], // teal
+  ["#E9E1F9", "#7731F8"], // purple
+  ["#CED2F7", "#313CF8"], // indigo
+  ["#D1ECF8", "#0193D7"], // blue
+  ["#CEF5BC", "#38BB00"], // green
+  ["#C5F7E4", "#00A767"], // emerald
+] as const;
+
+export type AvatarGradient = readonly [string, string];
+
 const URI_PREFIXES = [
   "data:",
   "http://",
@@ -75,4 +93,16 @@ export const getAvatarColor = (
 ): string => {
   const baseSeed = seed ?? fallbackName ?? 0;
   return AVATAR_COLORS[hashSeed(baseSeed) % AVATAR_COLORS.length];
+};
+
+/**
+ * Deterministically maps a seed to one of the gradient backgrounds, so a given
+ * user always resolves to the same [start, end] pair.
+ */
+export const getAvatarGradient = (
+  seed?: number | string | null,
+  fallbackName?: string | null,
+): AvatarGradient => {
+  const baseSeed = seed ?? fallbackName ?? 0;
+  return AVATAR_GRADIENTS[hashSeed(baseSeed) % AVATAR_GRADIENTS.length];
 };


### PR DESCRIPTION
### Replaced the 19 colors to 10 gradients

**What was Added**

- 10 gradients defined in code (avatar.ts) — each is a start→end color pair (e.g. light pink → hot pink). No image files; they're drawn by the app, so zero app-size cost.
- A getAvatarGradient() helper — picks which of the 10 gradients a person gets, based on their user ID. It's deterministic: the same person always gets the same gradient.
- A new AvatarBackground component — the reusable piece that actually paints the gradient behind the initials. It renders the gradient diagonally (top-left → bottom-right). It also intentionally "bleeds" a couple pixels past the edge so no rim/gap shows if there's a border around it.
- Tests — confirming the gradient pick is stable per user and returns valid colors.

**What was Changed**

- UserAvatar (the avatar used everywhere — lists, chat, members, etc.) — now shows the gradient behind the initials instead of a flat color.
- Onboarding & Edit Profile screens — the "no photo yet" placeholder circle (the one with the person icon) now uses the same gradient too, so it's consistent. Added overflow: hidden so the gradient stays clipped to the circle.
- Profile screen bell dot (from earlier) — the little unread dot on the notification bell was restyled to match the chat tab's dot (red with a white ring).

**What was Removed**

- The border around the Profile card's avatar — that faint 1px grey ring. It was causing a visible "gap"/rim around the gradient (the old solid color was peeking through the translucent border), and it was inconsistent with every other avatar in the app, which has no border. Removed it so the gradient runs cleanly to the edge.

---

**After**

<img width="585" height="1266" alt="IMG_0793" src="https://github.com/user-attachments/assets/b77cca0b-cdd0-406b-bf4f-d06d4bd469bb" />
<img width="585" height="1266" alt="IMG_0794" src="https://github.com/user-attachments/assets/bacb8eb4-2981-4790-a8a7-afa74f24b2e2" />
