### PR TITLE
copy: discover (Home)

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -27,11 +27,12 @@ export interface EventItemProps {
 }
 
 const BADGE_ICON_SIZE = 10;
-const VALID_BADGES = ['Pending', 'Hosting', 'Joined'];
+const VALID_BADGES = ['Pending', 'Requested', 'Hosting', 'Joined'];
 
 const getBadgeIcon = (badgeLabel: string) => {
   switch (badgeLabel) {
     case 'Pending':
+    case 'Requested':
       return <PendingIcon width={9.5} height={9.5} />;
     case 'Hosting':
       return <HostingIcon width={BADGE_ICON_SIZE} height={BADGE_ICON_SIZE} />;

--- a/src/components/__tests__/EventCard.test.tsx
+++ b/src/components/__tests__/EventCard.test.tsx
@@ -97,6 +97,13 @@ describe('EventCard', () => {
       expect(screen.getByText('Pending')).toBeTruthy();
     });
 
+    it('should show Requested badge', () => {
+      render(<EventCard {...defaultProps} badgeLabel="Requested" />);
+
+      expect(screen.getByTestId('event-card-badge')).toBeTruthy();
+      expect(screen.getByText('Requested')).toBeTruthy();
+    });
+
     it('should show Hosting badge', () => {
       render(<EventCard {...defaultProps} badgeLabel="Hosting" />);
 

--- a/src/context/EventsContext.tsx
+++ b/src/context/EventsContext.tsx
@@ -221,9 +221,9 @@ export const EventsProvider = ({
       }
       logger.error('Failed to fetch events', err);
       if (isAbortError(err)) {
-        setError('Unable to load events. Request timed out.');
+        setError('Unable to load plans.');
       } else {
-        setError('Unable to load events. Pull to refresh.');
+        setError('Unable to load plans.');
       }
     } finally {
       if (requestId === eventsRequestIdRef.current) {

--- a/src/context/__tests__/EventsContext.rendering.test.tsx
+++ b/src/context/__tests__/EventsContext.rendering.test.tsx
@@ -994,7 +994,7 @@ describe('EventsContext - Rendering Tests', () => {
 
       await waitFor(() => {
         expect(capturedCtx).not.toBeNull();
-        expect(capturedCtx!.error).toBe('Unable to load events. Pull to refresh.');
+        expect(capturedCtx!.error).toBe('Unable to load plans.');
       });
     });
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -146,7 +146,7 @@ const HomeScreen = () => {
       if (!user) return undefined;
       if (event.ownerId === user.id) return 'Hosting';
       if (joinedEventIds.has(event.id)) return 'Joined';
-      if (isEventRequested(event.id)) return 'Pending';
+      if (isEventRequested(event.id)) return 'Requested';
       return undefined;
     },
     [user, joinedEventIds, isEventRequested],
@@ -203,7 +203,7 @@ const HomeScreen = () => {
   const newestSections = useMemo<EventSection[]>(() => {
     if (discoverableEvents) {
       return buildSingleEventSection(
-        'Newest',
+        'Newest created',
         [...discoverableEvents].sort(sortEventsByCreatedAtDesc),
         getBadgeLabel,
       );
@@ -286,8 +286,8 @@ const HomeScreen = () => {
 
   const discoverEmptyState = (
     <EmptyState
-      title="Nothing Happening Here (Yet!)"
-      description="There are currently no events available. Please check back later."
+      title="Nothing happening yet"
+      description="Create a plan and see who else is free."
       imageSource={require('@assets/empty-state/discover.png')}
     />
   );
@@ -360,7 +360,7 @@ const HomeScreen = () => {
           onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}
         >
           <View style={styles.headerSpacing}>
-            <Text style={styles.headerTitle}>Discover Events</Text>
+            <Text style={styles.headerTitle}>Discover</Text>
           </View>
           <View style={styles.filtersRow}>
             <SegmentedControl
@@ -384,7 +384,7 @@ const HomeScreen = () => {
       />
       <EventActionBadge
         visible={showReportedBadge}
-        label="Event Reported, Admins are looking into it"
+        label="Report submitted. We'll review it shortly."
         onHidden={() => {
           setShowReportedBadge(false);
           navigation.setParams({ showEventReportedBadge: false });
@@ -392,7 +392,7 @@ const HomeScreen = () => {
       />
       <EventActionBadge
         visible={showEventDeletedBadge}
-        label="Event Deleted"
+        label="Plan deleted"
         onHidden={() => {
           setShowEventDeletedBadge(false);
           navigation.setParams({ showEventDeletedBadge: false });
@@ -400,7 +400,7 @@ const HomeScreen = () => {
       />
       <EventActionBadge
         visible={showEventLeftBadge}
-        label="Event left"
+        label="You left the plan"
         onHidden={() => {
           setShowEventLeftBadge(false);
           navigation.setParams({ showEventLeftBadge: false });
@@ -408,7 +408,7 @@ const HomeScreen = () => {
       />
       <NotificationAccessModal
         visible={showNoAccessModal}
-        message="You no longer have access to this event. Explore other events nearby."
+        message="You no longer have access to this plan. Explore other plans nearby."
         onDismiss={() => {
           setShowNoAccessModal(false);
           navigation.setParams({ showNoAccessModal: false });

--- a/src/screens/__tests__/HomeScreen.rendering.test.tsx
+++ b/src/screens/__tests__/HomeScreen.rendering.test.tsx
@@ -162,9 +162,9 @@ describe('HomeScreen Rendering', () => {
     it('displays error message and retry button', () => {
       mockEventsValue.isLoading = false;
       mockEventsValue.events = [];
-      mockEventsValue.error = 'Unable to load events.';
+      mockEventsValue.error = 'Unable to load plans.';
       const { getByText } = render(<HomeScreen />);
-      expect(getByText('Unable to load events.')).toBeTruthy();
+      expect(getByText('Unable to load plans.')).toBeTruthy();
       expect(getByText('Try again')).toBeTruthy();
     });
 
@@ -182,9 +182,9 @@ describe('HomeScreen Rendering', () => {
       mockEventsValue.events = [];
       const { getByTestId } = render(<HomeScreen />);
       expect(getByTestId('empty-state')).toBeTruthy();
-      expect(getByTestId('empty-state-title').props.children).toBe('Nothing Happening Here (Yet!)');
+      expect(getByTestId('empty-state-title').props.children).toBe('Nothing happening yet');
       expect(getByTestId('empty-state-description').props.children).toContain(
-        'no events available',
+        'Create a plan',
       );
     });
   });
@@ -442,7 +442,7 @@ describe('HomeScreen Rendering', () => {
       expect(getByTestId('event-card-badge')).toBeTruthy();
     });
 
-    it('shows Pending badge for requested events', () => {
+    it('shows Requested badge for requested events', () => {
       mockEventsValue.events = [createTodayEvent({ id: '99', ownerId: 999 })];
       mockEventsValue.isEventRequested = jest.fn().mockReturnValue(true);
       const { getByTestId } = render(<HomeScreen />);
@@ -458,9 +458,9 @@ describe('HomeScreen Rendering', () => {
   });
 
   describe('Header', () => {
-    it('renders Discover Events header', () => {
+    it('renders Discover header', () => {
       const { getByText } = render(<HomeScreen />);
-      expect(getByText('Discover Events')).toBeTruthy();
+      expect(getByText('Discover')).toBeTruthy();
     });
   });
 

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -114,17 +114,17 @@ describe('HomeScreen', () => {
       }
     });
 
-    it('should return "Pending" for events with pending requests', () => {
+    it('should return "Requested" for events with pending requests', () => {
       const isEventRequested = (eventId: string) => eventId === '99';
       const pendingEvent = { ...mockEvents[0], id: '99', ownerId: 999 };
 
       const getBadgeLabelWithPending = (event: typeof mockEvents[0]): string | undefined => {
         if (event.ownerId === user.id) return 'Hosting';
-        if (isEventRequested(event.id)) return 'Pending';
+        if (isEventRequested(event.id)) return 'Requested';
         return undefined;
       };
 
-      expect(getBadgeLabelWithPending(pendingEvent)).toBe('Pending');
+      expect(getBadgeLabelWithPending(pendingEvent)).toBe('Requested');
     });
   });
 
@@ -204,7 +204,7 @@ describe('HomeScreen', () => {
 
   describe('Error State', () => {
     it('should show error when error exists and not loading', () => {
-      const error = 'Unable to load events.';
+      const error = 'Unable to load plans.';
       const isLoading = false;
       const events: typeof mockEvents = [];
 
@@ -213,7 +213,7 @@ describe('HomeScreen', () => {
     });
 
     it('should not show error when loading', () => {
-      const error = 'Unable to load events.';
+      const error = 'Unable to load plans.';
       const isLoading = true;
       const events: typeof mockEvents = [];
 


### PR DESCRIPTION
Copy-only. Header 'Discover Events'->'Discover', empty state, load errors -> 'Unable to load plans.', card badge 'Pending'->'Requested' (adds 'Requested' to EventCard whitelist), toasts, no-access modal.