### PR TITLE
copy: event details

### DIFF
--- a/src/components/EventActionOverlay.prompts.tsx
+++ b/src/components/EventActionOverlay.prompts.tsx
@@ -78,8 +78,8 @@ export const InvitePrompt = ({
   return (
     <View style={styles.prompt}>
       <TextInput
-        accessibilityLabel="Send an intro about you and why you would like to join."
-        placeholder="Send an intro about you and why you would like to join."
+        accessibilityLabel="Share a short intro with the host"
+        placeholder="Share a short intro with the host"
         placeholderTextColor={colors.subText}
         multiline
         value={inviteMessage}
@@ -104,7 +104,7 @@ export const InvitePrompt = ({
         ]}
         testID="action-item-invite"
       >
-        <Text style={styles.sendLabel}>{inviteSubmitting ? 'Sending…' : 'Send Introduction'}</Text>
+        <Text style={styles.sendLabel}>{inviteSubmitting ? 'Sending…' : 'Send request'}</Text>
       </Pressable>
     </View>
   );
@@ -198,8 +198,8 @@ export const ReportPrompt = ({
   return (
     <View style={styles.prompt}>
       <TextInput
-        accessibilityLabel="Tell us why you are reporting this event"
-        placeholder="Tell us why you are reporting this event"
+        accessibilityLabel="Tell us why you're reporting this plan"
+        placeholder="Tell us why you're reporting this plan"
         placeholderTextColor={colors.subText}
         multiline
         value={reportMessage}
@@ -224,7 +224,7 @@ export const ReportPrompt = ({
         ]}
         testID="action-item-submit-report"
       >
-        <Text style={styles.sendLabel}>{reportSubmitting ? 'Submitting…' : 'Submit Report'}</Text>
+        <Text style={styles.sendLabel}>{reportSubmitting ? 'Submitting…' : 'Submit report'}</Text>
       </Pressable>
     </View>
   );
@@ -242,7 +242,7 @@ export const ActionMenu = ({ items }: ActionMenuProps) => (
 export const IntroMessagePrompt = ({ introMessage, onDismiss }: IntroMessagePromptProps) => (
   <View style={styles.prompt}>
     <View style={styles.promptHeader}>
-      <Text style={styles.promptTitle}>Your Introduction</Text>
+      <Text style={styles.promptTitle}>Your intro</Text>
       <Text style={styles.introMessageText}>{`"${introMessage}"`}</Text>
     </View>
     <Pressable

--- a/src/components/__tests__/EventActionOverlay.test.tsx
+++ b/src/components/__tests__/EventActionOverlay.test.tsx
@@ -90,14 +90,14 @@ describe('EventActionOverlay', () => {
       render(<EventActionOverlay {...inviteProps} />);
 
       expect(
-        screen.getByPlaceholderText('Send an intro about you and why you would like to join.'),
+        screen.getByPlaceholderText('Share a short intro with the host'),
       ).toBeTruthy();
     });
 
-    it('should show "Send Introduction" button text', () => {
+    it('should show "Send request" button text', () => {
       render(<EventActionOverlay {...inviteProps} />);
 
-      expect(screen.getByText('Send Introduction')).toBeTruthy();
+      expect(screen.getByText('Send request')).toBeTruthy();
     });
 
     it('should call onInviteMessageChange when text changes', () => {
@@ -105,7 +105,7 @@ describe('EventActionOverlay', () => {
       render(<EventActionOverlay {...inviteProps} onInviteMessageChange={onInviteMessageChange} />);
 
       const input = screen.getByPlaceholderText(
-        'Send an intro about you and why you would like to join.',
+        'Share a short intro with the host',
       );
       fireEvent.changeText(input, 'Hello, I would love to join!');
 
@@ -151,7 +151,7 @@ describe('EventActionOverlay', () => {
       render(<EventActionOverlay {...inviteProps} inviteMessage="I am excited to join!" />);
 
       const input = screen.getByPlaceholderText(
-        'Send an intro about you and why you would like to join.',
+        'Share a short intro with the host',
       );
       expect(input.props.value).toBe('I am excited to join!');
     });
@@ -424,20 +424,20 @@ describe('EventActionOverlay', () => {
     it('should render text input for reason', () => {
       render(<EventActionOverlay {...reportProps} />);
 
-      expect(screen.getByPlaceholderText('Tell us why you are reporting this event')).toBeTruthy();
+      expect(screen.getByPlaceholderText("Tell us why you're reporting this plan")).toBeTruthy();
     });
 
-    it('should show "Submit Report" button text', () => {
+    it('should show "Submit report" button text', () => {
       render(<EventActionOverlay {...reportProps} />);
 
-      expect(screen.getByText('Submit Report')).toBeTruthy();
+      expect(screen.getByText('Submit report')).toBeTruthy();
     });
 
     it('should call onReportMessageChange when text changes', () => {
       const onReportMessageChange = jest.fn();
       render(<EventActionOverlay {...reportProps} onReportMessageChange={onReportMessageChange} />);
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
       fireEvent.changeText(input, 'This event is spam');
 
       expect(onReportMessageChange).toHaveBeenCalledWith('This event is spam');
@@ -481,7 +481,7 @@ describe('EventActionOverlay', () => {
     it('should display current report message value', () => {
       render(<EventActionOverlay {...reportProps} reportMessage="This is inappropriate content" />);
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
       expect(input.props.value).toBe('This is inappropriate content');
     });
   });
@@ -611,10 +611,10 @@ describe('EventActionOverlay', () => {
       expect(screen.getByTestId('action-item-done')).toBeTruthy();
     });
 
-    it('should show "Your Introduction" title', () => {
+    it('should show "Your intro" title', () => {
       render(<EventActionOverlay {...viewIntroProps} />);
 
-      expect(screen.getByText('Your Introduction')).toBeTruthy();
+      expect(screen.getByText('Your intro')).toBeTruthy();
     });
 
     it('should show intro message in quotes', () => {
@@ -719,7 +719,7 @@ describe('EventActionOverlay', () => {
       );
 
       const input = screen.getByPlaceholderText(
-        'Send an intro about you and why you would like to join.',
+        'Share a short intro with the host',
       );
 
       // Type a message
@@ -747,7 +747,7 @@ describe('EventActionOverlay', () => {
         />,
       );
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
 
       // Type a report reason
       fireEvent.changeText(input, 'This event contains inappropriate content');
@@ -821,10 +821,10 @@ describe('EventActionOverlay', () => {
       );
 
       const input = screen.getByPlaceholderText(
-        'Send an intro about you and why you would like to join.',
+        'Share a short intro with the host',
       );
       expect(input.props.accessibilityLabel).toBe(
-        'Send an intro about you and why you would like to join.',
+        'Share a short intro with the host',
       );
     });
 
@@ -839,8 +839,8 @@ describe('EventActionOverlay', () => {
         />,
       );
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
-      expect(input.props.accessibilityLabel).toBe('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
+      expect(input.props.accessibilityLabel).toBe("Tell us why you're reporting this plan");
     });
   });
 });

--- a/src/screens/EventDetailsScreen.tsx
+++ b/src/screens/EventDetailsScreen.tsx
@@ -213,7 +213,7 @@ const EventDetailsScreenContent = ({
           {isOverlay ? (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="Close event details"
+              accessibilityLabel="Close"
               onPress={() => {
                 triggerHaptic('light');
                 handleOverlayClose();
@@ -232,7 +232,7 @@ const EventDetailsScreenContent = ({
               <ChevronLeftIcon width={24} height={24} color={colors.text} />
             </Pressable>
           )}
-          <Text style={styles.fallbackText}>We couldn't find that event.</Text>
+          <Text style={styles.fallbackText}>We couldn't find that plan.</Text>
         </View>
       </SafeAreaView>
     );
@@ -250,7 +250,7 @@ const EventDetailsScreenContent = ({
     maxAge: event.maxAge,
   });
 
-  const ctaLabel = hasPendingRequest ? 'Pending Request' : 'Interested';
+  const ctaLabel = hasPendingRequest ? 'Request pending' : 'Request to join';
 
   // Show standard CTA only for non-owners who haven't joined
   const showStandardCTA = !isOwner && !isConversationMember;
@@ -283,7 +283,7 @@ const EventDetailsScreenContent = ({
         {isOverlay ? (
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Close event details"
+            accessibilityLabel="Close"
             onPress={() => {
               triggerHaptic('light');
               handleOverlayClose();
@@ -314,7 +314,7 @@ const EventDetailsScreenContent = ({
             </Pressable>
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="More event actions"
+              accessibilityLabel="More actions"
               onPress={() => {
                 triggerHaptic('light');
                 setShowMenuOverlay(true);
@@ -584,7 +584,7 @@ const EventDetailsScreen = ({ onOverlayClose }: EventDetailsScreenProps = {}) =>
           },
         });
         if (response.status === 404) {
-          // The event was deleted; the "couldn't find that event" fallback
+          // The event was deleted; the "couldn't find that plan" fallback
           // handles this, so don't treat it as an error.
           if (!isCancelled) {
             setFetchedEvent(null);
@@ -629,7 +629,7 @@ const EventDetailsScreen = ({ onOverlayClose }: EventDetailsScreenProps = {}) =>
               {isOverlay ? (
                 <Pressable
                   accessibilityRole="button"
-                  accessibilityLabel="Close event details"
+                  accessibilityLabel="Close"
                   onPress={() => {
                     triggerHaptic('light');
                     handleOverlayClose();
@@ -648,7 +648,7 @@ const EventDetailsScreen = ({ onOverlayClose }: EventDetailsScreenProps = {}) =>
                   <ChevronLeftIcon width={24} height={24} color={colors.text} />
                 </Pressable>
               )}
-              <Text style={styles.fallbackText}>We couldn't find that event.</Text>
+              <Text style={styles.fallbackText}>We couldn't find that plan.</Text>
             </>
           )}
         </View>

--- a/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/EventDetailsScreen.rendering.test.tsx
@@ -257,7 +257,7 @@ jest.mock('@components/EventActionOverlay', () => {
             />
             {props.reportError && <Text testID="report-error">{props.reportError}</Text>}
             <Pressable testID="submit-report-button" onPress={props.onSubmitReport}>
-              <Text>Submit Report</Text>
+              <Text>Submit report</Text>
             </Pressable>
           </View>
         );
@@ -276,10 +276,10 @@ jest.mock('@components/EventActionOverlay', () => {
         return (
           <View testID="pending-request-overlay">
             <Pressable testID="cancel-request-button" onPress={props.onCancelRequest}>
-              <Text>Cancel Request</Text>
+              <Text>Cancel request</Text>
             </Pressable>
             <Pressable testID="report-event-button" onPress={props.onReportEvent}>
-              <Text>Report Event</Text>
+              <Text>Report plan</Text>
             </Pressable>
           </View>
         );
@@ -402,7 +402,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
     it('renders audience information correctly for group event', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      const audienceLine = 'Group, All Gender, 18 to 35 years';
+      const audienceLine = 'Group, All genders, 18 to 35 years';
       expect(getByText(audienceLine)).toBeTruthy();
     });
 
@@ -417,7 +417,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
 
       const { getByText } = render(<EventDetailsScreen />);
 
-      const audienceLine = '1:1, All Gender, 21 to 40 years';
+      const audienceLine = '1:1, All genders, 21 to 40 years';
       expect(getByText(audienceLine)).toBeTruthy();
 
       // Restore the spy to avoid polluting other tests
@@ -427,7 +427,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
     it('renders "Details" section heading', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Details')).toBeTruthy();
+      expect(getByText('Plan details')).toBeTruthy();
     });
   });
 
@@ -443,10 +443,10 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(getByText('Hosted by you')).toBeTruthy();
     });
 
-    it('shows "Go to Chat" CTA button for host', () => {
+    it('shows "Go to chat" CTA button for host', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Go to Chat')).toBeTruthy();
+      expect(getByText('Go to chat')).toBeTruthy();
     });
 
     it('shows going row for host', () => {
@@ -455,29 +455,29 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(getByTestId('going-row')).toBeTruthy();
     });
 
-    it('shows "Event details updated" badge after a short delay when route param is set', () => {
+    it('shows "Plan details updated" badge after a short delay when route param is set', () => {
       jest.useFakeTimers();
       const routeSpy = jest
         .spyOn(require('@react-navigation/native'), 'useRoute')
         .mockReturnValue(createMockRoute('1', 'MyEvents', true));
 
       const { getByText, queryByText } = render(<EventDetailsScreen />);
-      expect(queryByText('Event details updated')).toBeNull();
+      expect(queryByText('Plan details updated')).toBeNull();
 
       act(() => {
         jest.advanceTimersByTime(350);
       });
 
-      expect(getByText('Event details updated')).toBeTruthy();
+      expect(getByText('Plan details updated')).toBeTruthy();
 
       routeSpy.mockRestore();
       jest.useRealTimers();
     });
 
-    it('opens chat when "Go to Chat" is pressed', () => {
+    it('opens chat when "Go to chat" is pressed', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      const chatButton = getByText('Go to Chat');
+      const chatButton = getByText('Go to chat');
       fireEvent.press(chatButton);
 
       expect(mockChatState.setActiveConversation).toHaveBeenCalledWith(mockEventConversation.id);
@@ -502,7 +502,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       });
     });
 
-    it('shows Edit Details and Delete Event menu items for host', async () => {
+    it('shows Edit plan and Delete plan menu items for host', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
@@ -510,19 +510,19 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(buttons[1]); // Menu button
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-edit-details')).toBeTruthy();
-        expect(getByTestId('menu-item-delete-event')).toBeTruthy();
+        expect(getByTestId('menu-item-edit-plan')).toBeTruthy();
+        expect(getByTestId('menu-item-delete-plan')).toBeTruthy();
       });
     });
 
-    it('navigates to edit screen when Edit Details is pressed', async () => {
+    it('navigates to edit screen when Edit plan is pressed', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        const editButton = getByTestId('menu-item-edit-details');
+        const editButton = getByTestId('menu-item-edit-plan');
         fireEvent.press(editButton);
       });
       act(() => {
@@ -538,20 +538,20 @@ describe('EventDetailsScreen Rendering Tests', () => {
       }));
     });
 
-    it('shows delete confirmation when Delete Event is pressed', async () => {
+    it('shows delete confirmation when Delete plan is pressed', async () => {
       const { getByTestId, getAllByRole, queryByTestId } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        const deleteButton = getByTestId('menu-item-delete-event');
+        const deleteButton = getByTestId('menu-item-delete-plan');
         fireEvent.press(deleteButton);
       });
 
       await waitFor(() => {
         expect(getByTestId('confirm-overlay')).toBeTruthy();
-        expect(getByTestId('confirm-title')).toHaveTextContent('Delete this event?');
+        expect(getByTestId('confirm-title')).toHaveTextContent('Delete this plan?');
       });
     });
 
@@ -562,7 +562,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-delete-event'));
+        fireEvent.press(getByTestId('menu-item-delete-plan'));
       });
 
       await waitFor(() => {
@@ -586,10 +586,10 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(getByText('Members')).toBeTruthy();
     });
 
-    it('displays "No requests yet" when there are no pending requests', () => {
+    it('displays "No requests" when there are no pending requests', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('No requests yet')).toBeTruthy();
+      expect(getByText('No requests')).toBeTruthy();
     });
 
     it('displays pending join requests for host', async () => {
@@ -635,24 +635,24 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(getByText(`Hosted by ${mockNonOwnedEvent.hostName}`)).toBeTruthy();
     });
 
-    it('shows "Interested" CTA button for guest', () => {
+    it('shows "Request to join" CTA button for guest', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Interested')).toBeTruthy();
+      expect(getByText('Request to join')).toBeTruthy();
     });
 
     it('shows going row for guest viewers', () => {
       const { getByTestId } = render(<EventDetailsScreen />);
 
       expect(getByTestId('going-row')).toBeTruthy();
-      expect(getByTestId('going-count-label')).toHaveTextContent('2 Going');
+      expect(getByTestId('going-count-label')).toHaveTextContent('2 Joined');
     });
 
     it('redirects to login when guest tries to join', async () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
-      // Press Interested button
-      const interestedButton = getByText('Interested');
+      // Press Request to join button
+      const interestedButton = getByText('Request to join');
       fireEvent.press(interestedButton);
 
       // Should show invite overlay
@@ -688,17 +688,17 @@ describe('EventDetailsScreen Rendering Tests', () => {
       }];
     });
 
-    it('shows "Interested" button for non-member', () => {
+    it('shows "Request to join" button for non-member', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Interested')).toBeTruthy();
+      expect(getByText('Request to join')).toBeTruthy();
     });
 
     it('shows going row for non-joined viewers', () => {
       const { getByTestId } = render(<EventDetailsScreen />);
 
       expect(getByTestId('going-row')).toBeTruthy();
-      expect(getByTestId('going-count-label')).toHaveTextContent('1 Going');
+      expect(getByTestId('going-count-label')).toHaveTextContent('1 Joined');
     });
 
     it('shows fallback host going state when conversation is missing', () => {
@@ -706,7 +706,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByTestId } = render(<EventDetailsScreen />);
 
       expect(getByTestId('going-row')).toBeTruthy();
-      expect(getByTestId('going-count-label')).toHaveTextContent('1 Going');
+      expect(getByTestId('going-count-label')).toHaveTextContent('1 Joined');
       expect(getByTestId('going-avatar-0')).toBeTruthy();
     });
 
@@ -735,24 +735,24 @@ describe('EventDetailsScreen Rendering Tests', () => {
       routeSpy.mockRestore();
     });
 
-    it('opens invite prompt when Interested is pressed', async () => {
+    it('opens invite prompt when Request to join is pressed', async () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
-      fireEvent.press(getByText('Interested'));
+      fireEvent.press(getByText('Request to join'));
 
       await waitFor(() => {
         expect(getByTestId('invite-overlay')).toBeTruthy();
       });
     });
 
-    it('shows Report Event option in menu for non-member', async () => {
+    it('shows Report plan option in menu for non-member', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-report-event')).toBeTruthy();
+        expect(getByTestId('menu-item-report-plan')).toBeTruthy();
       });
     });
 
@@ -765,7 +765,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
       // Open invite prompt
-      fireEvent.press(getByText('Interested'));
+      fireEvent.press(getByText('Request to join'));
 
       await waitFor(() => {
         expect(getByTestId('invite-overlay')).toBeTruthy();
@@ -795,7 +795,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
       // Open invite prompt
-      fireEvent.press(getByText('Interested'));
+      fireEvent.press(getByText('Request to join'));
 
       await waitFor(() => {
         expect(getByTestId('invite-overlay')).toBeTruthy();
@@ -823,48 +823,48 @@ describe('EventDetailsScreen Rendering Tests', () => {
       }];
     });
 
-    it('shows "Go to Chat" button for members', () => {
+    it('shows "Go to chat" button for members', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Go to Chat')).toBeTruthy();
+      expect(getByText('Go to chat')).toBeTruthy();
     });
 
     it('shows going row for joined members', () => {
       const { getByTestId } = render(<EventDetailsScreen />);
 
       expect(getByTestId('going-row')).toBeTruthy();
-      expect(getByTestId('going-count-label')).toHaveTextContent('2 Going');
+      expect(getByTestId('going-count-label')).toHaveTextContent('2 Joined');
     });
 
-    it('does not show "Interested" button for members', () => {
+    it('does not show "Request to join" button for members', () => {
       const { queryByText } = render(<EventDetailsScreen />);
 
-      expect(queryByText('Interested')).toBeNull();
+      expect(queryByText('Request to join')).toBeNull();
     });
 
-    it('shows Leave Event option in menu for members', async () => {
+    it('shows Leave plan option in menu for members', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-leave-event')).toBeTruthy();
+        expect(getByTestId('menu-item-leave-plan')).toBeTruthy();
       });
     });
 
-    it('shows Report Event option in menu for members', async () => {
+    it('shows Report plan option in menu for members', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-report-event')).toBeTruthy();
+        expect(getByTestId('menu-item-report-plan')).toBeTruthy();
       });
     });
 
-    it('shows View Intro Message option in menu for members', async () => {
+    it('shows View intro message option in menu for members', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
@@ -875,19 +875,19 @@ describe('EventDetailsScreen Rendering Tests', () => {
       });
     });
 
-    it('shows leave confirmation when Leave Event is pressed', async () => {
+    it('shows leave confirmation when Leave plan is pressed', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-leave-event'));
+        fireEvent.press(getByTestId('menu-item-leave-plan'));
       });
 
       await waitFor(() => {
         expect(getByTestId('confirm-overlay')).toBeTruthy();
-        expect(getByTestId('confirm-title')).toHaveTextContent('Leave this event?');
+        expect(getByTestId('confirm-title')).toHaveTextContent('Leave this plan?');
       });
     });
 
@@ -900,7 +900,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-leave-event'));
+        fireEvent.press(getByTestId('menu-item-leave-plan'));
       });
 
       await waitFor(() => {
@@ -944,21 +944,21 @@ describe('EventDetailsScreen Rendering Tests', () => {
       }];
     });
 
-    it('shows "Pending Request" button when request is pending', () => {
+    it('shows "Request pending" button when request is pending', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText('Pending Request')).toBeTruthy();
+      expect(getByText('Request pending')).toBeTruthy();
     });
 
     it('disables CTA button when request is pending', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      const pendingButton = getByText('Pending Request').parent;
+      const pendingButton = getByText('Request pending').parent;
       // The button should be disabled (not respond to press)
       expect(pendingButton).toBeTruthy();
     });
 
-    it('shows Cancel Request option in menu for pending state', async () => {
+    it('shows Cancel request option in menu for pending state', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
@@ -969,7 +969,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       });
     });
 
-    it('cancels request when Cancel Request is pressed', async () => {
+    it('cancels request when Cancel request is pressed', async () => {
       fetchMock.mockResponseOnce('', { status: 200 });
 
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
@@ -1001,7 +1001,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
     it('renders fallback UI when event is not found', () => {
       const { getByText } = render(<EventDetailsScreen />);
 
-      expect(getByText("We couldn't find that event.")).toBeTruthy();
+      expect(getByText("We couldn't find that plan.")).toBeTruthy();
     });
 
     it('shows back button on fallback screen', () => {
@@ -1067,7 +1067,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
     });
   });
 
-  describe('Report Event Flow', () => {
+  describe('Report plan Flow', () => {
     beforeEach(() => {
       mockAuthState.user = mockUser;
       mockAuthState.token = 'test-token';
@@ -1079,14 +1079,14 @@ describe('EventDetailsScreen Rendering Tests', () => {
       }];
     });
 
-    it('opens report overlay when Report Event is selected', async () => {
+    it('opens report overlay when Report plan is selected', async () => {
       const { getByTestId, getAllByRole } = render(<EventDetailsScreen />);
 
       // Open menu
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-report-event'));
+        fireEvent.press(getByTestId('menu-item-report-plan'));
       });
 
       await waitFor(() => {
@@ -1101,7 +1101,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-report-event'));
+        fireEvent.press(getByTestId('menu-item-report-plan'));
       });
 
       await waitFor(() => {
@@ -1122,7 +1122,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        fireEvent.press(getByTestId('menu-item-report-event'));
+        fireEvent.press(getByTestId('menu-item-report-plan'));
       });
 
       await waitFor(() => {
@@ -1158,9 +1158,9 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-report-event')).toBeTruthy();
+        expect(getByTestId('menu-item-report-plan')).toBeTruthy();
       });
-      fireEvent.press(getByTestId('menu-item-report-event'));
+      fireEvent.press(getByTestId('menu-item-report-plan'));
 
       await waitFor(() => {
         expect(getByTestId('report-message-input')).toBeTruthy();
@@ -1298,9 +1298,9 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-delete-event')).toBeTruthy();
+        expect(getByTestId('menu-item-delete-plan')).toBeTruthy();
       });
-      fireEvent.press(getByTestId('menu-item-delete-event'));
+      fireEvent.press(getByTestId('menu-item-delete-plan'));
 
       await waitFor(() => {
         expect(getByTestId('confirm-button')).toBeTruthy();
@@ -1368,9 +1368,9 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-delete-event')).toBeTruthy();
+        expect(getByTestId('menu-item-delete-plan')).toBeTruthy();
       });
-      fireEvent.press(getByTestId('menu-item-delete-event'));
+      fireEvent.press(getByTestId('menu-item-delete-plan'));
 
       await waitFor(() => {
         expect(getByTestId('confirm-button')).toBeTruthy();
@@ -1397,9 +1397,9 @@ describe('EventDetailsScreen Rendering Tests', () => {
       fireEvent.press(getAllByRole('button')[1]);
 
       await waitFor(() => {
-        expect(getByTestId('menu-item-leave-event')).toBeTruthy();
+        expect(getByTestId('menu-item-leave-plan')).toBeTruthy();
       });
-      fireEvent.press(getByTestId('menu-item-leave-event'));
+      fireEvent.press(getByTestId('menu-item-leave-plan'));
 
       await waitFor(() => {
         expect(getByTestId('confirm-button')).toBeTruthy();
@@ -1427,7 +1427,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
       // Open invite prompt
-      fireEvent.press(getByText('Interested'));
+      fireEvent.press(getByText('Request to join'));
 
       await waitFor(() => {
         fireEvent.changeText(getByTestId('invite-message-input'), 'Hello!');
@@ -1452,7 +1452,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByText, getByTestId } = render(<EventDetailsScreen />);
 
       // Open invite prompt
-      fireEvent.press(getByText('Interested'));
+      fireEvent.press(getByText('Request to join'));
 
       await waitFor(() => {
         expect(getByTestId('invite-message-input')).toBeTruthy();
@@ -1502,12 +1502,12 @@ describe('EventDetailsScreen Rendering Tests', () => {
       expect(queryByText('Members')).toBeNull();
     });
 
-    it('opens JoinRequests when 1:1 host taps "Go to Chat" without existing conversations', () => {
+    it('opens JoinRequests when 1:1 host taps "Go to chat" without existing conversations', () => {
       mockChatState.conversations = [];
 
       const { getByText } = render(<EventDetailsScreen />);
 
-      fireEvent.press(getByText('Go to Chat'));
+      fireEvent.press(getByText('Go to chat'));
 
       expect(mockNavigate).toHaveBeenCalledWith(
         'JoinRequests',
@@ -1645,7 +1645,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
 
       const { getByLabelText, queryByLabelText } = render(<EventDetailsScreen />);
 
-      expect(queryByLabelText('Close event details')).toBeNull();
+      expect(queryByLabelText('Close')).toBeNull();
 
       fireEvent.press(getByLabelText('Go back'));
 
@@ -1776,7 +1776,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
       const { getByText, queryByText } = render(<EventDetailsScreen />);
 
       expect(getByText('Accepted')).toBeTruthy();
-      expect(getByText('No accepted members yet')).toBeTruthy();
+      expect(getByText('No accepted requests')).toBeTruthy();
       expect(getByText('Members you accept will appear here')).toBeTruthy();
       expect(queryByText('Host')).toBeNull();
     });
@@ -1849,7 +1849,7 @@ describe('EventDetailsScreen Rendering Tests', () => {
         );
 
       const { getByLabelText, queryByLabelText } = render(<EventDetailsScreen />);
-      const closeButton = getByLabelText('Close event details');
+      const closeButton = getByLabelText('Close');
 
       expect(queryByLabelText('Go back')).toBeNull();
       expect(closeButton.props.style).toEqual(

--- a/src/screens/__tests__/EventDetailsScreen.test.tsx
+++ b/src/screens/__tests__/EventDetailsScreen.test.tsx
@@ -60,7 +60,7 @@ describe('EventDetailsScreen', () => {
         maxAge: event.maxAge,
       });
 
-      expect(audienceLine).toBe('Group, All Gender, 18 to 35 years');
+      expect(audienceLine).toBe('Group, All genders, 18 to 35 years');
     });
   });
 

--- a/src/screens/event-details/EventDetailsCTA.tsx
+++ b/src/screens/event-details/EventDetailsCTA.tsx
@@ -80,7 +80,7 @@ const EventDetailsCTA = ({
             onPress={onOpenChat}
             style={[styles.ctaButton, isOwner && styles.ctaButtonSecondary]}
           >
-            <Text style={[styles.ctaLabel, isOwner && styles.ctaLabelSecondary]}>Go to Chat</Text>
+            <Text style={[styles.ctaLabel, isOwner && styles.ctaLabelSecondary]}>Go to chat</Text>
           </ScalePressable>
         </View>
       </View>

--- a/src/screens/event-details/EventDetailsInfo.tsx
+++ b/src/screens/event-details/EventDetailsInfo.tsx
@@ -122,7 +122,7 @@ const EventDetailsInfo = ({
               )}
             </View>
             <Text style={styles.goingLabel} testID="going-count-label">
-              {`${goingCount} Going`}
+              {`${goingCount} Joined`}
             </Text>
           </View>
         )}
@@ -130,7 +130,7 @@ const EventDetailsInfo = ({
 
       <View style={[styles.divider, { marginTop: 20, marginBottom: 24 }]} />
 
-      <Text style={styles.sectionHeading}>Details</Text>
+      <Text style={styles.sectionHeading}>Plan details</Text>
       <View style={styles.detailDiv}>
         <View style={styles.detailRowTop}>
           <View style={styles.detailIconContainerTop}>

--- a/src/screens/event-details/EventDetailsMembers.tsx
+++ b/src/screens/event-details/EventDetailsMembers.tsx
@@ -72,12 +72,8 @@ const EventDetailsMembers = (props: EventDetailsMembersProps) => {
         <View style={styles.listContainer}>
           {members.length === 0 ? (
             <EmptyState
-              title={isAccepted ? 'No accepted members yet' : 'No members yet'}
-              description={
-                isAccepted
-                  ? 'Members you accept will appear here'
-                  : 'Members who join will appear here'
-              }
+              title={isAccepted ? 'No accepted requests' : 'No members'}
+              description="People you accept will appear here."
               imageSource={EMPTY_ILLUSTRATION}
               imageWidth={EMPTY_ILLUSTRATION_WIDTH}
               imageHeight={EMPTY_ILLUSTRATION_HEIGHT}
@@ -125,8 +121,8 @@ const EventDetailsMembers = (props: EventDetailsMembersProps) => {
           <Text style={styles.emptyStateText}>{error}</Text>
         ) : members.length === 0 ? (
           <EmptyState
-            title="No members yet"
-            description="Members who join will appear here"
+            title="No members"
+            description="People you accept will appear here."
             imageSource={EMPTY_ILLUSTRATION}
             imageWidth={EMPTY_ILLUSTRATION_WIDTH}
             imageHeight={EMPTY_ILLUSTRATION_HEIGHT}

--- a/src/screens/event-details/EventDetailsOverlayRoutes.tsx
+++ b/src/screens/event-details/EventDetailsOverlayRoutes.tsx
@@ -169,10 +169,10 @@ const EventDetailsOverlayRoutes = ({
         isVisible={showDeleteConfirm}
         onBackdropPress={isDeleting ? undefined : onDeleteCancel}
         type="confirm"
-        title="Delete this event?"
-        description="This will remove the event for everyone and can't be undone."
-        confirmLabel="Delete event"
-        cancelLabel="Keep event"
+        title="Delete this plan?"
+        description="This will remove the plan for everyone and can't be undone."
+        confirmLabel="Delete plan"
+        cancelLabel="Keep plan"
         confirmTone="destructive"
         onConfirm={onDelete}
         onCancel={onDeleteCancel}
@@ -215,9 +215,9 @@ const EventDetailsOverlayRoutes = ({
         isVisible={showLeaveConfirm}
         onBackdropPress={isLeaving ? undefined : onLeaveCancel}
         type="confirm"
-        title="Leave this event?"
+        title="Leave this plan?"
         description="You'll need to request to join again if you change your mind."
-        confirmLabel="Leave Event"
+        confirmLabel="Leave plan"
         cancelLabel="Stay"
         confirmTone="destructive"
         onConfirm={onLeaveEvent}
@@ -248,8 +248,8 @@ const EventDetailsOverlayRoutes = ({
         title={`Remove ${memberTitleName}?`}
         description={
           isSingleEvent
-            ? 'They will be removed from this event and private chat.'
-            : 'They will be removed from the group chat and will need to request to join again.'
+            ? 'They will be removed from this plan and your 1:1 chat will be deleted.'
+            : 'They will be removed from this plan and group chat.'
         }
         confirmLabel={`Remove ${memberFirstName}`}
         cancelLabel="Cancel"
@@ -261,17 +261,17 @@ const EventDetailsOverlayRoutes = ({
       />
       <EventActionBadge
         visible={showEventUpdatedBadge}
-        label="Event details updated"
+        label="Plan details updated"
         onHidden={onEventUpdatedBadgeHidden}
       />
       <EventActionBadge
         visible={showRequestSentBadge}
-        label="Requested to join"
+        label="Request sent"
         onHidden={onRequestSentBadgeHidden}
       />
       <EventActionBadge
         visible={showRequestCancelledBadge}
-        label="Requested to join cancelled"
+        label="Request cancelled"
         onHidden={onRequestCancelledBadgeHidden}
       />
       <EventActionBadge

--- a/src/screens/event-details/HostRequestTabs.tsx
+++ b/src/screens/event-details/HostRequestTabs.tsx
@@ -130,8 +130,8 @@ const HostRequestTabs = ({
           <View style={{ width: pagerWidth > 0 ? pagerWidth : '50%', minHeight: 200 }}>
             {pendingRequests.length === 0 ? (
               <EmptyState
-                title="No requests yet"
-                description="Join requests will appear here"
+                title="No requests"
+                description="Join requests will appear here."
                 imageSource={EMPTY_ILLUSTRATION}
                 imageWidth={EMPTY_ILLUSTRATION_WIDTH}
                 imageHeight={EMPTY_ILLUSTRATION_HEIGHT}
@@ -161,8 +161,8 @@ const HostRequestTabs = ({
             {isSingleEvent ? (
               acceptedRequests.length === 0 ? (
                 <EmptyState
-                  title="No accepted members yet"
-                  description="Members you accept will appear here"
+                  title="No accepted requests"
+                  description="People you accept will appear here."
                   imageSource={EMPTY_ILLUSTRATION}
                   imageWidth={EMPTY_ILLUSTRATION_WIDTH}
                   imageHeight={EMPTY_ILLUSTRATION_HEIGHT}
@@ -182,8 +182,8 @@ const HostRequestTabs = ({
               )
             ) : confirmedMembers.length === 0 ? (
               <EmptyState
-                title="No members yet"
-                description="Members who join will appear here"
+                title="No members"
+                description="People you accept will appear here."
                 imageSource={EMPTY_ILLUSTRATION}
                 imageWidth={EMPTY_ILLUSTRATION_WIDTH}
                 imageHeight={EMPTY_ILLUSTRATION_HEIGHT}

--- a/src/screens/event-details/useEventDetailsActions.ts
+++ b/src/screens/event-details/useEventDetailsActions.ts
@@ -157,7 +157,7 @@ export const useEventDetailsActions = ({
     }
     const trimmed = inviteMessage.trim();
     if (!trimmed.length) {
-      setInviteError('Please include a brief note for the host.');
+      setInviteError('Add a short intro for the host.');
       return;
     }
     triggerHaptic('submit');
@@ -177,7 +177,7 @@ export const useEventDetailsActions = ({
       if (response.status === 409) {
         setHasPendingRequest(true);
         markEventRequested(event.id);
-        setInviteError('You already have a pending request for this event.');
+        setInviteError('You already have a pending request for this plan.');
         trackEvent('join_request_failed', {
           ...eventAnalyticsParams,
           status_code: response.status,
@@ -208,7 +208,7 @@ export const useEventDetailsActions = ({
             status_code: response.status,
             reason_category: 'forbidden',
           }).catch(() => undefined);
-          throw new Error('You are unable to join this event.');
+          throw new Error("You can't join this plan.");
         }
         if (response.status === 404) {
           failureTracked = true;
@@ -217,7 +217,7 @@ export const useEventDetailsActions = ({
             status_code: response.status,
             reason_category: 'not_found',
           }).catch(() => undefined);
-          throw new Error('This event is no longer available.');
+          throw new Error('This plan is no longer available.');
         }
         failureTracked = true;
         trackEvent('join_request_failed', {
@@ -225,7 +225,7 @@ export const useEventDetailsActions = ({
           status_code: response.status,
           reason_category: 'api_error',
         }).catch(() => undefined);
-        throw new Error(serverMsg || 'Unable to send request right now.');
+        throw new Error(serverMsg || "Couldn't send request. Please try again.");
       }
       setInviteMessage('');
       setShowInvitePrompt(false);
@@ -242,7 +242,7 @@ export const useEventDetailsActions = ({
       }
       logger.error('Failed to send invite', err);
       setInviteError(
-        err instanceof Error ? err.message : 'Unable to send request. Please try again.',
+        err instanceof Error ? err.message : "Couldn't send request. Please try again.",
       );
     } finally {
       setIsSendingInvite(false);
@@ -315,7 +315,7 @@ export const useEventDetailsActions = ({
       });
     } catch (err) {
       logger.error('Failed to delete event', err);
-      setDeleteError('Unable to delete this event. Please try again.');
+      setDeleteError("Couldn't delete this plan. Please try again.");
     } finally {
       setIsDeleting(false);
     }
@@ -376,7 +376,7 @@ export const useEventDetailsActions = ({
     }
     const trimmed = reportMessage.trim();
     if (!trimmed.length) {
-      setReportError('Please tell us why you are reporting this event.');
+      setReportError("Please tell us why you're reporting this plan.");
       return;
     }
     triggerHaptic('submit');
@@ -392,11 +392,11 @@ export const useEventDetailsActions = ({
         body: JSON.stringify({ reason: trimmed }),
       });
       if (response.status === 409) {
-        setReportError('You have already reported this event.');
+        setReportError('You have already reported this plan.');
         return;
       }
       if (!response.ok) {
-        throw new Error('Unable to submit report right now.');
+        throw new Error("Couldn't submit report. Please try again.");
       }
       setReportMessage('');
       setShowReportPrompt(false);
@@ -424,7 +424,7 @@ export const useEventDetailsActions = ({
     } catch (err) {
       logger.error('Failed to submit report', err);
       setReportError(
-        err instanceof Error ? err.message : 'Unable to submit report. Please try again.',
+        err instanceof Error ? err.message : "Couldn't submit report. Please try again.",
       );
     } finally {
       setIsSubmittingReport(false);
@@ -487,7 +487,7 @@ export const useEventDetailsActions = ({
       });
     } catch (err) {
       logger.error('Failed to leave event', err);
-      setLeaveError('Unable to leave this event. Please try again.');
+      setLeaveError('Unable to leave this plan. Please try again.');
     } finally {
       setIsLeaving(false);
     }
@@ -521,44 +521,44 @@ export const useEventDetailsActions = ({
 
   const menuItems = useMemo(() => {
     if (isOwner) {
-      // Host: Edit Details, Delete Event
+      // Host: Edit plan, Delete plan
       return [
-        { label: 'Edit Details', onPress: handleMenuEdit },
-        { label: 'Delete Event', onPress: handleMenuDelete, destructive: true },
+        { label: 'Edit plan', onPress: handleMenuEdit },
+        { label: 'Delete plan', onPress: handleMenuDelete, destructive: true },
       ];
     }
     if (isConversationMember) {
-      // Joined: View Intro Message, Leave Event, Report Event
+      // Joined: View intro message, Leave plan, Report plan
       return [
-        { label: 'View Intro Message', onPress: handleMenuViewIntro },
-        { label: 'Leave Event', onPress: handleLeavePrompt, destructive: true },
+        { label: 'View intro message', onPress: handleMenuViewIntro },
+        { label: 'Leave plan', onPress: handleLeavePrompt, destructive: true },
         {
-          label: 'Report Event',
+          label: 'Report plan',
           onPress: handleMenuReportEvent,
           destructive: true,
         },
       ];
     }
     if (hasPendingRequest) {
-      // Pending: View Intro Message, Cancel Request, Report Event
+      // Pending: View intro message, Cancel request, Report plan
       return [
-        { label: 'View Intro Message', onPress: handleMenuViewIntro },
+        { label: 'View intro message', onPress: handleMenuViewIntro },
         {
-          label: 'Cancel Request',
+          label: 'Cancel request',
           onPress: handleMenuCancelRequest,
           loading: isCancellingRequest,
         },
         {
-          label: 'Report Event',
+          label: 'Report plan',
           onPress: handleMenuReportEvent,
           destructive: true,
         },
       ];
     }
-    // Not joined: Report Event
+    // Not joined: Report plan
     return [
       {
-        label: 'Report Event',
+        label: 'Report plan',
         onPress: handleMenuReportEvent,
         destructive: true,
       },

--- a/src/screens/event-details/useHostRequestActions.ts
+++ b/src/screens/event-details/useHostRequestActions.ts
@@ -188,7 +188,7 @@ export const useHostRequestActions = ({
       setRemovedMemberBadgeLabel(firstName.length > 0 ? `${firstName} removed` : 'Member removed');
     } catch (err) {
       logger.error('Failed to remove member', err);
-      setRemoveError('Unable to remove this member. Please try again.');
+      setRemoveError("Couldn't remove this member. Please try again.");
     } finally {
       setIsRemovingMember(false);
     }

--- a/src/utils/__tests__/eventDisplay.test.ts
+++ b/src/utils/__tests__/eventDisplay.test.ts
@@ -29,16 +29,16 @@ describe("eventDisplay", () => {
   });
 
   describe("formatAudienceLabel", () => {
-    it("uses All Gender for open-gender events", () => {
+    it("uses All genders for open-gender events", () => {
       expect(
         formatAudienceLabel({ gender: "Any", minAge: 18, maxAge: 35 }),
-      ).toBe("All Gender, 18 to 35 years");
+      ).toBe("All genders, 18 to 35 years");
     });
 
-    it("uses All Age for the canonical full age range", () => {
+    it("uses All ages for the canonical full age range", () => {
       expect(
         formatAudienceLabel({ gender: "Female", minAge: 18, maxAge: 60 }),
-      ).toBe("Female, All Age");
+      ).toBe("Female, All ages");
     });
 
     it("formats a single-year audience range", () => {
@@ -117,7 +117,7 @@ describe("eventDisplay", () => {
           minAge: 18,
           maxAge: 60,
         }),
-      ).toBe("Group, All Gender, All Age");
+      ).toBe("Group, All genders, All ages");
     });
   });
 

--- a/src/utils/eventDisplay.ts
+++ b/src/utils/eventDisplay.ts
@@ -113,7 +113,7 @@ export const formatVerboseAgeLabel = (
   }
 
   if (isAllAge(normalized.minAge, normalized.maxAge)) {
-    return "All Age";
+    return "All ages";
   }
 
   if (normalized.minAge === normalized.maxAge) {
@@ -129,7 +129,7 @@ export const formatAudienceLabel = ({
   maxAge,
 }: AudienceInput): string => {
   const parts: string[] = [];
-  const genderLabel = isAllGender(gender) ? "All Gender" : getGenderLabel(gender);
+  const genderLabel = isAllGender(gender) ? "All genders" : getGenderLabel(gender);
   const ageLabel = formatVerboseAgeLabel(minAge, maxAge);
 
   if (genderLabel) {


### PR DESCRIPTION
Copy-only. CTA/menu/prompts/confirms/toasts/errors -> plan wording + sentence case. Audience normalized to 'All genders'/'All ages' (eventDisplay.ts, shared with Past Events). Not-found error split deferred.