### PR TITLE
copy: pending requests

### DIFF
--- a/src/screens/PendingRequestsScreen.tsx
+++ b/src/screens/PendingRequestsScreen.tsx
@@ -118,8 +118,8 @@ const PendingRequestsScreen = () => {
         >
           {pendingRequests.length === 0 ? (
             <EmptyState
-              title="No pending requests"
-              description="Join requests will appear here"
+              title="No requests"
+              description="Join requests will appear here."
               imageSource={EMPTY_ILLUSTRATION}
               imageWidth={EMPTY_ILLUSTRATION_WIDTH}
               imageHeight={EMPTY_ILLUSTRATION_HEIGHT}

--- a/src/screens/__tests__/PendingRequestsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/PendingRequestsScreen.rendering.test.tsx
@@ -223,7 +223,7 @@ describe('PendingRequestsScreen Rendering', () => {
     it('should show empty state when no pending requests', () => {
       mockChatValue.joinRequestsByConversation = { 1: [] };
       const { getByText } = render(<PendingRequestsScreen />);
-      expect(getByText('No pending requests')).toBeTruthy();
+      expect(getByText('No requests')).toBeTruthy();
     });
 
     it('should show empty state when all requests are approved', () => {
@@ -239,7 +239,7 @@ describe('PendingRequestsScreen Rendering', () => {
         }],
       };
       const { getByText } = render(<PendingRequestsScreen />);
-      expect(getByText('No pending requests')).toBeTruthy();
+      expect(getByText('No requests')).toBeTruthy();
       expect(getByText('Requests')).toBeTruthy();
     });
   });


### PR DESCRIPTION
Copy-only. Empty state 'No pending requests'->'No requests' + description period.