### PR TITLE
copy: chat thread

### DIFF
--- a/src/components/ChatEventHeader.tsx
+++ b/src/components/ChatEventHeader.tsx
@@ -83,7 +83,7 @@ const ChatEventHeader = ({
       pressableStyle={styles.titlePressable}
       style={styles.titlePressableInner}
       onPress={onTitlePress}
-      accessibilityLabel={titleAccessibilityLabel ?? "View event details"}
+      accessibilityLabel={titleAccessibilityLabel ?? "View plan details"}
       testID={testID}
     >
       {titleInner}

--- a/src/components/EventActionOverlay.prompts.tsx
+++ b/src/components/EventActionOverlay.prompts.tsx
@@ -198,8 +198,8 @@ export const ReportPrompt = ({
   return (
     <View style={styles.prompt}>
       <TextInput
-        accessibilityLabel="Tell us why you are reporting this event"
-        placeholder="Tell us why you are reporting this event"
+        accessibilityLabel="Tell us why you're reporting this plan"
+        placeholder="Tell us why you're reporting this plan"
         placeholderTextColor={colors.subText}
         multiline
         value={reportMessage}
@@ -224,7 +224,7 @@ export const ReportPrompt = ({
         ]}
         testID="action-item-submit-report"
       >
-        <Text style={styles.sendLabel}>{reportSubmitting ? 'Submitting…' : 'Submit Report'}</Text>
+        <Text style={styles.sendLabel}>{reportSubmitting ? 'Submitting…' : 'Submit report'}</Text>
       </Pressable>
     </View>
   );

--- a/src/components/__tests__/EventActionOverlay.test.tsx
+++ b/src/components/__tests__/EventActionOverlay.test.tsx
@@ -424,20 +424,20 @@ describe('EventActionOverlay', () => {
     it('should render text input for reason', () => {
       render(<EventActionOverlay {...reportProps} />);
 
-      expect(screen.getByPlaceholderText('Tell us why you are reporting this event')).toBeTruthy();
+      expect(screen.getByPlaceholderText("Tell us why you're reporting this plan")).toBeTruthy();
     });
 
-    it('should show "Submit Report" button text', () => {
+    it('should show "Submit report" button text', () => {
       render(<EventActionOverlay {...reportProps} />);
 
-      expect(screen.getByText('Submit Report')).toBeTruthy();
+      expect(screen.getByText('Submit report')).toBeTruthy();
     });
 
     it('should call onReportMessageChange when text changes', () => {
       const onReportMessageChange = jest.fn();
       render(<EventActionOverlay {...reportProps} onReportMessageChange={onReportMessageChange} />);
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
       fireEvent.changeText(input, 'This event is spam');
 
       expect(onReportMessageChange).toHaveBeenCalledWith('This event is spam');
@@ -481,7 +481,7 @@ describe('EventActionOverlay', () => {
     it('should display current report message value', () => {
       render(<EventActionOverlay {...reportProps} reportMessage="This is inappropriate content" />);
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
       expect(input.props.value).toBe('This is inappropriate content');
     });
   });
@@ -747,7 +747,7 @@ describe('EventActionOverlay', () => {
         />,
       );
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
 
       // Type a report reason
       fireEvent.changeText(input, 'This event contains inappropriate content');
@@ -839,8 +839,8 @@ describe('EventActionOverlay', () => {
         />,
       );
 
-      const input = screen.getByPlaceholderText('Tell us why you are reporting this event');
-      expect(input.props.accessibilityLabel).toBe('Tell us why you are reporting this event');
+      const input = screen.getByPlaceholderText("Tell us why you're reporting this plan");
+      expect(input.props.accessibilityLabel).toBe("Tell us why you're reporting this plan");
     });
   });
 });

--- a/src/hooks/useSingleEventMemberActions.ts
+++ b/src/hooks/useSingleEventMemberActions.ts
@@ -31,7 +31,7 @@ const DEFAULT_REPORT_ERRORS = {
 export const useSingleEventMemberActions = ({
   eventId,
   onSuccess,
-  removeErrorTitle = 'Unable to remove member',
+  removeErrorTitle = "Couldn't remove this person.",
   reportErrorMessages,
 }: UseSingleEventMemberActionsOptions) => {
   const { authFetch, token } = useAuth();
@@ -113,7 +113,7 @@ export const useSingleEventMemberActions = ({
         token,
         timeoutMs: null,
         fetchImpl: authFetch,
-        errorMessage: 'Unable to remove member.',
+        errorMessage: 'Please try again.',
       });
 
       await onSuccess?.();

--- a/src/screens/ChatThreadScreen.tsx
+++ b/src/screens/ChatThreadScreen.tsx
@@ -44,7 +44,6 @@ import { buildEventMemberSubtitle, buildOneToOneSubtitle } from '@utils/chatHead
 const ANDROID_KEYBOARD_GAP = spacing.xs;
 
 interface ComposerProps {
-  activeConversationName: string;
   composerBottomPadding: number;
   draft: string;
   isSendDisabled: boolean;
@@ -53,7 +52,6 @@ interface ComposerProps {
 }
 
 const ChatComposer = ({
-  activeConversationName,
   composerBottomPadding,
   draft,
   isSendDisabled,
@@ -66,7 +64,7 @@ const ChatComposer = ({
   >
     <View style={styles.composerInputWrapper}>
       <TextInput
-        placeholder={`Message ${activeConversationName}`}
+        placeholder="Write a message"
         value={draft}
         onChangeText={onDraftChange}
         style={styles.composerInput}
@@ -500,7 +498,7 @@ const ChatThreadScreen = () => {
     const timeText = item.pending
       ? 'Sending…'
       : item.failed
-        ? 'Failed. Tap to retry.'
+        ? "Couldn't send. Tap to retry."
         : new Date(item.createdAt).toLocaleTimeString([], {
             hour: '2-digit',
             minute: '2-digit',
@@ -578,8 +576,6 @@ const ChatThreadScreen = () => {
   };
 
   const composerProps: ComposerProps = {
-    // Placeholder name matches the header title: counterpart in 1:1, group/event name otherwise.
-    activeConversationName: headerTitle,
     composerBottomPadding,
     draft,
     isSendDisabled,
@@ -621,7 +617,7 @@ const ChatThreadScreen = () => {
           }
         }}
         titleAccessibilityLabel={
-          canOpenSingleChatActions ? 'Open member actions' : 'View event details'
+          canOpenSingleChatActions ? 'Open actions' : 'View plan details'
         }
         rightElement={
           <>
@@ -631,7 +627,7 @@ const ChatThreadScreen = () => {
             {canViewJoinRequests && pendingJoinRequestCount > 0 ? (
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="View join requests"
+                accessibilityLabel="View requests"
                 onPress={handleOpenJoinRequests}
                 style={styles.joinIconButton}
               >

--- a/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
+++ b/src/screens/__tests__/ChatThreadScreen.rendering.test.tsx
@@ -197,9 +197,9 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { getByText } = render(<ChatThreadScreen />);
 
-      // Subtitle: "Group · 2 Members" (memberIds: [1, 2]) — two parts, dot separator.
+      // Subtitle: "Group · 2 members" (memberIds: [1, 2]) — two parts, dot separator.
       expect(getByText('Group')).toBeTruthy();
-      expect(getByText('2 Members')).toBeTruthy();
+      expect(getByText('2 members')).toBeTruthy();
     });
 
     it('should render counterpart name and "One to one, <date>" subtitle in 1:1 mode', () => {
@@ -282,7 +282,7 @@ describe('ChatThreadScreen Rendering', () => {
       setupMocks();
       const { getByPlaceholderText } = render(<ChatThreadScreen />);
 
-      expect(getByPlaceholderText('Message Coffee Meetup Chat')).toBeTruthy();
+      expect(getByPlaceholderText('Write a message')).toBeTruthy();
     });
 
     it('should render send button', () => {
@@ -296,7 +296,7 @@ describe('ChatThreadScreen Rendering', () => {
       setupMocks();
       const { getByPlaceholderText } = render(<ChatThreadScreen />);
 
-      const input = getByPlaceholderText('Message Coffee Meetup Chat');
+      const input = getByPlaceholderText('Write a message');
       fireEvent.changeText(input, 'Test message');
 
       expect(input.props.value).toBe('Test message');
@@ -306,7 +306,7 @@ describe('ChatThreadScreen Rendering', () => {
       setupMocks();
       const { getByPlaceholderText, getByLabelText } = render(<ChatThreadScreen />);
 
-      const input = getByPlaceholderText('Message Coffee Meetup Chat');
+      const input = getByPlaceholderText('Write a message');
       fireEvent.changeText(input, 'Hello!');
 
       const sendButton = getByLabelText('Send message');
@@ -329,7 +329,7 @@ describe('ChatThreadScreen Rendering', () => {
       setupMocks();
       const { getByPlaceholderText, getByLabelText } = render(<ChatThreadScreen />);
 
-      const input = getByPlaceholderText('Message Coffee Meetup Chat');
+      const input = getByPlaceholderText('Write a message');
       fireEvent.changeText(input, 'Hello!');
 
       const sendButton = getByLabelText('Send message');
@@ -340,13 +340,13 @@ describe('ChatThreadScreen Rendering', () => {
   });
 
   describe('Message Retry on Failed Messages', () => {
-    it('should display "Failed. Tap to retry." for failed messages', () => {
+    it('should display "Couldn\'t send. Tap to retry." for failed messages', () => {
       setupMocks({
         chatOverrides: { messages: [mockFailedMessage] },
       });
       const { getByText } = render(<ChatThreadScreen />);
 
-      expect(getByText('Failed. Tap to retry.')).toBeTruthy();
+      expect(getByText("Couldn't send. Tap to retry.")).toBeTruthy();
     });
 
     it('should call retryMessage when tapping on failed message', () => {
@@ -390,7 +390,7 @@ describe('ChatThreadScreen Rendering', () => {
 
       // Subtitle is NOT replaced by the connecting indicator
       expect(getByText('Group')).toBeTruthy();
-      expect(getByText('2 Members')).toBeTruthy();
+      expect(getByText('2 members')).toBeTruthy();
     });
 
     it('should display error message when error exists', () => {
@@ -421,7 +421,7 @@ describe('ChatThreadScreen Rendering', () => {
       const { getByPlaceholderText } = render(<ChatThreadScreen />);
 
       // Should still show input field
-      expect(getByPlaceholderText('Message Coffee Meetup Chat')).toBeTruthy();
+      expect(getByPlaceholderText('Write a message')).toBeTruthy();
     });
   });
 
@@ -527,7 +527,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { getByLabelText, getByText } = render(<ChatThreadScreen />);
 
-      expect(getByLabelText('View join requests')).toBeTruthy();
+      expect(getByLabelText('View requests')).toBeTruthy();
       expect(getByText('1')).toBeTruthy();
     });
 
@@ -544,7 +544,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { getByLabelText, getByText } = render(<ChatThreadScreen />);
 
-      expect(getByLabelText('View join requests')).toBeTruthy();
+      expect(getByLabelText('View requests')).toBeTruthy();
       expect(getByText('1')).toBeTruthy();
     });
 
@@ -559,7 +559,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { queryByLabelText } = render(<ChatThreadScreen />);
 
-      expect(queryByLabelText('View join requests')).toBeNull();
+      expect(queryByLabelText('View requests')).toBeNull();
     });
 
     it('should not display join request icon inside a 1:1 private chat', () => {
@@ -591,7 +591,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { queryByLabelText, queryByText } = render(<ChatThreadScreen />);
 
-      expect(queryByLabelText('View join requests')).toBeNull();
+      expect(queryByLabelText('View requests')).toBeNull();
       expect(queryByText('2')).toBeNull();
     });
 
@@ -623,7 +623,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { queryByLabelText, queryByText } = render(<ChatThreadScreen />);
 
-      expect(queryByLabelText('View join requests')).toBeNull();
+      expect(queryByLabelText('View requests')).toBeNull();
       expect(queryByText('1')).toBeNull();
     });
 
@@ -654,7 +654,7 @@ describe('ChatThreadScreen Rendering', () => {
       });
       const { queryByLabelText } = render(<ChatThreadScreen />);
 
-      expect(queryByLabelText('View join requests')).toBeNull();
+      expect(queryByLabelText('View requests')).toBeNull();
     });
   });
 
@@ -805,7 +805,7 @@ describe('ChatThreadScreen Rendering', () => {
 
       const { getByPlaceholderText, getByLabelText, getByTestId } = render(<ChatThreadScreen />);
 
-      expect(getByPlaceholderText('Message Coffee Meetup Chat')).toBeTruthy();
+      expect(getByPlaceholderText('Write a message')).toBeTruthy();
       expect(getByLabelText('Send message')).toBeTruthy();
       expect(
         StyleSheet.flatten(getByTestId('chat-composer-container').props.style).paddingBottom
@@ -819,7 +819,7 @@ describe('ChatThreadScreen Rendering', () => {
 
       const { getByPlaceholderText, getByLabelText } = render(<ChatThreadScreen />);
 
-      expect(getByPlaceholderText('Message Coffee Meetup Chat')).toBeTruthy();
+      expect(getByPlaceholderText('Write a message')).toBeTruthy();
       expect(getByLabelText('Send message')).toBeTruthy();
     });
   });

--- a/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
+++ b/src/screens/__tests__/JoinRequestsScreen.rendering.test.tsx
@@ -341,9 +341,9 @@ describe('JoinRequestsScreen Rendering', () => {
     it('should render member count and date subtitle in group mode', () => {
       mockChatValue.conversations = [mockConversation()];
       const { getByText } = render(<JoinRequestsScreen />);
-      // Subtitle: "Group · 3 Members" (two parts, dot separator).
+      // Subtitle: "Group · 3 members" (two parts, dot separator).
       expect(getByText('Group')).toBeTruthy();
-      expect(getByText('3 Members')).toBeTruthy();
+      expect(getByText('3 members')).toBeTruthy();
     });
 
     it('should render back button', () => {

--- a/src/utils/__tests__/chatHeaderSubtitle.test.ts
+++ b/src/utils/__tests__/chatHeaderSubtitle.test.ts
@@ -35,7 +35,7 @@ describe('buildEventMemberSubtitle', () => {
         memberCount: 3,
         schedule: { eventDate },
       }),
-    ).toBe('Group, 3 Members');
+    ).toBe('Group, 3 members');
   });
 
   it('ignores the schedule (no date in the subtitle)', () => {
@@ -45,7 +45,7 @@ describe('buildEventMemberSubtitle', () => {
         memberCount: 5,
         schedule: { dateLabel: 'Today' },
       }),
-    ).toBe('Group, 5 Members');
+    ).toBe('Group, 5 members');
 
     expect(
       buildEventMemberSubtitle({
@@ -63,7 +63,7 @@ describe('buildEventMemberSubtitle', () => {
         memberCount: 2,
         schedule: undefined,
       }),
-    ).toBe('Group, 2 Members');
+    ).toBe('Group, 2 members');
   });
 
   it('handles a zero count', () => {
@@ -73,7 +73,7 @@ describe('buildEventMemberSubtitle', () => {
         memberCount: 0,
         schedule: { dateLabel: 'Today' },
       }),
-    ).toBe('Group, 0 Members');
+    ).toBe('Group, 0 members');
   });
 });
 

--- a/src/utils/chatHeaderSubtitle.ts
+++ b/src/utils/chatHeaderSubtitle.ts
@@ -45,7 +45,7 @@ export const buildEventMemberSubtitle = ({
   memberCount,
 }: EventMemberSubtitleOptions): string => {
   const typeLabel = groupType === 'Single' ? '1:1' : 'Group';
-  const noun = groupType === 'Single' ? 'Accepted' : 'Members';
+  const noun = groupType === 'Single' ? 'Accepted' : 'members';
   return `${typeLabel}, ${memberCount} ${noun}`;
 };
 


### PR DESCRIPTION
Copy-only. Group subtitle 'Members'->'members' (shared chatHeaderSubtitle, also JoinRequests), header a11y, placeholder->'Write a message', send-failed->Couldn't send, remove-member error, report prompt (identical to event-details). 1:1 subtitle deferred.